### PR TITLE
Issue 177 uisp duplicate ips

### DIFF
--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -54,7 +54,9 @@ def buildFlatGraph():
                         for ip in interface["addresses"]:
                             ip = ip["cidr"]
                             if isIpv4Permitted(ip):
-                                ipv4.append(fixSubnet(ip))
+                                ip = fixSubnet(ip)
+                                if ip not in ipv4:
+                                    ipv4.append(ip)
 
                     # TODO: Figure out Mikrotik IPv6?
                     mac = device['identification']['mac']
@@ -157,7 +159,9 @@ def buildFullGraph():
                     for ip in interface["addresses"]:
                         ip = ip["cidr"]
                         if isIpv4Permitted(ip):
-                            ipv4.append(fixSubnet(ip))
+                            ip = fixSubnet(ip)
+                            if ip not in ipv4:
+                                ipv4.append(ip)
 
                 # TODO: Figure out Mikrotik IPv6?
                 mac = device['identification']['mac']

--- a/src/testGraph.py
+++ b/src/testGraph.py
@@ -252,7 +252,7 @@ class TestGraph(unittest.TestCase):
         net.createNetworkJson()
         with open('network.json') as file:
             newFile = json.load(file)
-        with open('v1.3/network.example.json') as file:
+        with open('src/network.example.json') as file:
             exampleFile = json.load(file)
         self.assertEqual(newFile, exampleFile)
 


### PR DESCRIPTION
See #177 

Applies the request changes - UISP can report the same IP address on multiple interfaces. Add checks that IPv4 addresses are unique before adding them. Should work for both flat an hierarchical topology.

Also includes a 1-line fix to a unit test after repo paths changed.