### PR TITLE
Fix undefined names in Python code

### DIFF
--- a/src/LibreQoS.py
+++ b/src/LibreQoS.py
@@ -1057,12 +1057,13 @@ def refreshShapersUpdateOnly():
 					else:
 						removeDeviceIPsFromFilter(lastLoadedSubscriberCircuitsByID[circuitID])
 						# Delete HTB class, qdisc. Then recreat it.
-						classid = classIDofExistingCircuitID[circuitID]
-						circuit['classid'] = classid
+						classID = classIDofExistingCircuitID[circuitID]
+						circuit['classid'] = classID
 						delHTBclass(classID)
 						parentNodeClassID = classIDOfParentNodes[parentNodeOfCircuitID[circuitID]]
 						addCircuitHTBandQdisc(circuit, parentNodeClassID)
-						addDeviceIPsToFilter(newlyUpdatedSubscriberCircuitsByID[circuitID], cpuNum)
+						cpuNumHex = cpuNumOfParentNodeHex[parentNodeActual]
+						addDeviceIPsToFilter(newlyUpdatedSubscriberCircuitsByID[circuitID], cpuNumHex)
 				if devicesChanged:
 					parentNodeActual = circuit['ParentNode']
 					if parentNodeActual == 'none':


### PR DESCRIPTION
% `flake8 --exclude="./.*,./old" --show-source --statistics --select=E9,F63,F72,F82`
```
./src/LibreQoS.py:1062:19: F821 undefined name 'classID'
						delHTBclass(classID)
						            ^
./src/LibreQoS.py:1065:75: F821 undefined name 'cpuNum'
						addDeviceIPsToFilter(newlyUpdatedSubscriberCircuitsByID[circuitID], cpuNum)
						                                                                    ^
2     F821 undefined name 'classID'
```
These are both in the same block of code.  The first is caused by sometimes using `classid` and other times using `classID` so this PR uses the latter based on other code on nearby lines.  To fix the second, this PR borrows a bit of code from a few lines a bit further down.

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR focuses on runtime safety and correctness.
It does  _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).:
* __E9__ tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* __F63__ tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* __F7__ tests logic errors and syntax errors in type hints
* __F82__ tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.