### PR TITLE
python3 -m pip install -r requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+binpacking
+flask
+flask_httpauth
+flask_restful
+graphviz
+influxdb-client
+ipaddress
+psutil
+requests
+schedule
+waitress


### PR DESCRIPTION
https://pip.pypa.io/en/stable/user_guide/#requirements-files

This would simplify the installation instructions at: https://github.com/LibreQoE/LibreQoS/wiki/LibreQoS-v1.3-Installation-&-Usage-Guide-Physical-Server-and-Ubuntu-22.04#install-libreqos-and-dependencies