### PR TITLE
bugfix: change sqm mode to ack-filter was impossible

### DIFF
--- a/src/rust/lqos_node_manager/static/config.html
+++ b/src/rust/lqos_node_manager/static/config.html
@@ -209,7 +209,7 @@
                         <select id="sqmMode">
                             <option value="fq_codel">FQ_Codel</option>
                             <option value="cake diffserv4">Cake + Diffserv4</option>
-                            <option value="cake diffserv4 ackfilter">Cake + Diffserv4 + ACK Filter</option>
+                            <option value="cake diffserv4 ack-filter">Cake + Diffserv4 + ACK Filter</option>
                         </select>
                     </td>
                 </tr>


### PR DESCRIPTION
I got an error when editing option (SQM Mode) to turn on ack-filter by UI 

```
What is "ackfilter"?
Usage: ... cake [ bandwidth RATE | unlimited* | autorate-ingress ]
                [ rtt TIME | datacentre | lan | metro | regional |
                  internet* | oceanic | satellite | interplanetary ]
                [ besteffort | diffserv8 | diffserv4 | diffserv3* ]
                [ flowblind | srchost | dsthost | hosts | flows |
                  dual-srchost | dual-dsthost | triple-isolate* ]
                [ nat | nonat* ]
                [ wash | nowash* ]
                [ split-gso* | no-split-gso ]
                [ ack-filter | ack-filter-aggressive | no-ack-filter* ]
                [ memlimit LIMIT ]
                [ fwmark MASK ]
                [ ptm | atm | noatm* ] [ overhead N | conservative | raw* ]
                [ mpu N ] [ ingress | egress* ]
                (* marks defaults)
Command failed linux_tc.txt:4
```
Probbably this would help.