### PR TITLE
Build deb as part of Continuous Integration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,8 +35,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install tools
-      run: pushd src/rust; cargo install cargo-outdated; cargo install cargo-audit; popd
-    - name: Check for outdated dependencies
-      run: cd src/rust; cargo outdated -w --color=always --root-deps-only --exit-code 1
+      run: pushd src/rust; cargo install cargo-audit; popd
     - name: Audit for CVEs
       run: cd src/rust; cargo audit -c always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,8 +29,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install tools
       run: pushd src/rust; cargo install cargo-outdated; cargo install cargo-audit; popd
-    #- name: Check for outdated dependencies
-    #  run: cd src/rust; cargo outdated -w --color=always --root-deps-only --exit-code 1
     - name: Audit for CVEs
       run: cd src/rust; cargo audit -c always
   

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,11 @@ jobs:
       run: pushd src/rust; cargo build --verbose --all; popd
     - name: Run tests
       run: pushd src/rust; cargo test --verbose --all; popd
+    - name: Archive .deb file
+      uses: actions/upload-artifact@v3
+      with:
+        name: libreqos_1.4.-1_amd64.deb
+        path: src/dist/libreqos_1.4.-1_amd64.deb
   
   audit:
     strategy:
@@ -29,23 +34,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install tools
       run: pushd src/rust; cargo install cargo-outdated; cargo install cargo-audit; popd
+    - name: Check for outdated dependencies
+      run: cd src/rust; cargo outdated -w --color=always --root-deps-only --exit-code 1
     - name: Audit for CVEs
       run: cd src/rust; cargo audit -c always
-  
-  dpkg:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/upload-artifact@v3
-    - name: Install dependencies
-      run: sudo apt-get update; sudo apt-get install --no-install-recommends python3-pip clang gcc gcc-multilib llvm libelf-dev git nano graphviz curl screen llvm pkg-config linux-tools-common linux-tools-`uname r` libbpf-dev
-      if: matrix.os == 'ubuntu-latest'
-    - name: Build/Export
-      run: pushd src/rust; ./build_dpkg.sh --nostamp; popd
-      with:
-        name: libreqos_1.4.-1_amd64.deb
-        path: src/dist/libreqos_1.4.-1_amd64.deb

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,26 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install tools
       run: pushd src/rust; cargo install cargo-outdated; cargo install cargo-audit; popd
-    - name: Check for outdated dependencies
-      run: cd src/rust; cargo outdated -w --color=always --root-deps-only --exit-code 1
+    #- name: Check for outdated dependencies
+    #  run: cd src/rust; cargo outdated -w --color=always --root-deps-only --exit-code 1
     - name: Audit for CVEs
       run: cd src/rust; cargo audit -c always
+  
+  dpkg:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/upload-artifact@v3
+    - name: Install dependencies
+      run: sudo apt-get update; sudo apt-get install --no-install-recommends python3-pip clang gcc gcc-multilib llvm libelf-dev git nano graphviz curl screen llvm pkg-config linux-tools-common linux-tools-`uname r` libbpf-dev
+      if: matrix.os == 'ubuntu-latest'
+    - name: Build
+      run: pushd src/rust; ./build_dpkg.sh --nostamp; popd
+    - name: Export
+      with:
+        name: libreqos_1.4.-1_amd64.deb
+        path: src/dist/libreqos_1.4.-1_amd64.deb

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,8 @@ jobs:
       run: pushd src/rust; cargo build --verbose --all; popd
     - name: Run tests
       run: pushd src/rust; cargo test --verbose --all; popd
+    - name: Build .deb file
+      run: pushd src; ./build_dpkg.sh --nostamp; popd
     - name: Archive .deb file
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,9 +44,8 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update; sudo apt-get install --no-install-recommends python3-pip clang gcc gcc-multilib llvm libelf-dev git nano graphviz curl screen llvm pkg-config linux-tools-common linux-tools-`uname r` libbpf-dev
       if: matrix.os == 'ubuntu-latest'
-    - name: Build
+    - name: Build/Export
       run: pushd src/rust; ./build_dpkg.sh --nostamp; popd
-    - name: Export
       with:
         name: libreqos_1.4.-1_amd64.deb
         path: src/dist/libreqos_1.4.-1_amd64.deb

--- a/src/build_dpkg.sh
+++ b/src/build_dpkg.sh
@@ -5,6 +5,10 @@
 # This is all GPL2.
 
 BUILD_DATE=`date +%Y%m%d`
+if [ $1 = "--nostamp" ]
+then
+    BUILD_DATE=""
+fi
 PACKAGE=libreqos
 VERSION=1.4.$BUILD_DATE
 PKGVERSION=$PACKAGE


### PR DESCRIPTION
Build the `.deb` release as part of the Github Actions run. The .deb file is available for download as an artifact of that build for 90 days. Please squash this commit.