### PR TITLE
Rust licenses

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_rs"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 

--- a/src/rust/check_licenses.sh
+++ b/src/rust/check_licenses.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Checks all Rust projects for accidental inclusion of something GPL-3
+# licensed.
+
+PROJECTS="lqos_anonymous_stats_server lqos_bus lqos_config lqos_heimdall lqos_node_manager lqos_python lqos_queue_tracker lqos_setup lqos_sys lqos_utils lqosd lqusers xdp_iphash_to_cpu_cmdline xdp_pping"
+TOOL="cargo license --help"
+
+# Check that the tool exists
+if ! $TOOL &> /dev/null
+then
+    echo "Cargo License Tool not Found. Installing it."
+    cargo install cargo-license
+fi
+
+# Check every project
+for project in $PROJECTS
+do
+    pushd $project > /dev/null
+    if cargo license | grep "GPL-3"; then
+        echo "Warning: GPL3 detected in dependencies for $project"
+    fi
+    popd > /dev/null
+done

--- a/src/rust/lqos_anonymous_stats_server/Cargo.toml
+++ b/src/rust/lqos_anonymous_stats_server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_anonymous_stats_server"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 tokio = { version = "1.25.0", features = ["full"] }

--- a/src/rust/lqos_bus/Cargo.toml
+++ b/src/rust/lqos_bus/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_bus"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [features]
 default = ["equinix_tests"]

--- a/src/rust/lqos_config/Cargo.toml
+++ b/src/rust/lqos_config/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_config"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 thiserror = "1"

--- a/src/rust/lqos_heimdall/Cargo.toml
+++ b/src/rust/lqos_heimdall/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_heimdall"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 lqos_utils = { path = "../lqos_utils" }

--- a/src/rust/lqos_node_manager/Cargo.toml
+++ b/src/rust/lqos_node_manager/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_node_manager"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [features]
 default = ["equinix_tests"]

--- a/src/rust/lqos_python/Cargo.toml
+++ b/src/rust/lqos_python/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_python"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [lib]
 name = "lqos_python"

--- a/src/rust/lqos_queue_tracker/Cargo.toml
+++ b/src/rust/lqos_queue_tracker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_queue_tracker"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 thiserror = "1"

--- a/src/rust/lqos_setup/Cargo.toml
+++ b/src/rust/lqos_setup/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_setup"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 colored = "2"

--- a/src/rust/lqos_sys/Cargo.toml
+++ b/src/rust/lqos_sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_sys"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 nix = "0"

--- a/src/rust/lqos_utils/Cargo.toml
+++ b/src/rust/lqos_utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqos_utils"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/rust/lqosd/Cargo.toml
+++ b/src/rust/lqosd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqosd"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [features]
 default = ["equinix_tests"]

--- a/src/rust/lqtop/Cargo.toml
+++ b/src/rust/lqtop/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqtop"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 tokio = { version = "1", features = [ "rt", "macros", "net", "io-util", "time" ] }

--- a/src/rust/lqusers/Cargo.toml
+++ b/src/rust/lqusers/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lqusers"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/src/rust/xdp_iphash_to_cpu_cmdline/Cargo.toml
+++ b/src/rust/xdp_iphash_to_cpu_cmdline/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xdp_iphash_to_cpu_cmdline"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/src/rust/xdp_pping/Cargo.toml
+++ b/src/rust/xdp_pping/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xdp_pping"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-2.0-only"
 
 [dependencies]
 tokio = { version = "1", features = [ "rt", "macros", "net", "io-util", "time" ] }


### PR DESCRIPTION
In reference to https://github.com/LibreQoE/LibreQoS/issues/229

* Adds a license specifier (GPL 2 only) to all the `Cargo.toml` files.
* Adds a shell script that checks the licenses of all Rust dependencies, and warns you if GPL 3 is found. Since basically nobody in the known universe uses GPL3, this is rather pointless.

