### PR TITLE
Issue 291 capture time

### DIFF
--- a/src/lqos.example
+++ b/src/lqos.example
@@ -4,6 +4,7 @@
 # Where is LibreQoS installed?
 lqos_directory = '/opt/libreqos/src'
 queue_check_period_ms = 1000
+packet_capture_time = 10 # Number of seconds to capture packets in an analysis session
 
 [usage_stats]
 send_anonymous = true

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "dashmap",
  "log",
  "lqos_bus",
+ "lqos_config",
  "lqos_sys",
  "lqos_utils",
  "once_cell",

--- a/src/rust/lqos_bus/src/bus/response.rs
+++ b/src/rust/lqos_bus/src/bus/response.rs
@@ -91,7 +91,12 @@ pub enum BusResponse {
   FlowData(Vec<(FlowTransport, Option<FlowTransport>)>),
 
   /// The index of the new packet collection session
-  PacketCollectionSession(usize),
+  PacketCollectionSession{ 
+    /// The identifier of the capture session
+    session_id: usize, 
+    /// Number of seconds for which data will be captured
+    countdown: usize 
+  },
 
   /// Packet header dump
   PacketDump(Option<Vec<PacketHeader>>),

--- a/src/rust/lqos_config/src/etc.rs
+++ b/src/rust/lqos_config/src/etc.rs
@@ -30,6 +30,11 @@ pub struct EtcLqos {
 
   /// If present, defined anonymous usage stat sending
   pub usage_stats: Option<UsageStats>,
+
+  /// Defines for how many seconds a libpcap compatible capture should
+  /// run. Short times are good, there's a real performance penalty to
+  /// capturing high-throughput streams. Defaults to 10 seconds.
+  pub packet_capture_time: Option<usize>,
 }
 
 /// Represents a set of `sysctl` and `ethtool` tweaks that may be

--- a/src/rust/lqos_heimdall/Cargo.toml
+++ b/src/rust/lqos_heimdall/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 lqos_utils = { path = "../lqos_utils" }
 lqos_bus = { path = "../lqos_bus" }
 lqos_sys = { path = "../lqos_sys" }
+lqos_config = { path = "../lqos_config" }
 log = "0"
 zerocopy = {version = "0.6.1", features = [ "simd" ] }
 once_cell = "1.17.1"

--- a/src/rust/lqos_heimdall/src/lib.rs
+++ b/src/rust/lqos_heimdall/src/lib.rs
@@ -9,7 +9,7 @@ pub use config::{HeimdalConfig, HeimdallMode};
 mod flows;
 pub use flows::{expire_heimdall_flows, get_flow_stats};
 mod timeline;
-pub use timeline::{ten_second_packet_dump, ten_second_pcap, hyperfocus_on_target};
+pub use timeline::{n_second_packet_dump, n_second_pcap, hyperfocus_on_target};
 mod pcap;
 mod watchlist;
 use lqos_utils::fdtimer::periodic;

--- a/src/rust/lqos_node_manager/src/queue_info.rs
+++ b/src/rust/lqos_node_manager/src/queue_info.rs
@@ -143,8 +143,11 @@ pub async fn packet_dump(id: usize, _auth: AuthGuard) -> NoCache<Json<Vec<Packet
   NoCache::new(Json(result))
 }
 
-#[get("/api/pcap/<id>/capture.pcap")]
-pub async fn pcap(id: usize) -> Result<NoCache<NamedFile>, Status> {
+#[allow(unused_variables)]
+#[get("/api/pcap/<id>/<filename>")]
+pub async fn pcap(id: usize, filename: String) -> Result<NoCache<NamedFile>, Status> {
+  // The unusued _filename parameter is there to allow the changing of the
+  // filename on the client side. See Github issue 291.
   for r in bus_request(vec![BusRequest::GetPcapDump(id)]).await.unwrap() {
     if let BusResponse::PcapDump(Some(filename)) = r {
       return Ok(NoCache::new(NamedFile::open(filename).await.unwrap()));

--- a/src/rust/lqos_node_manager/src/queue_info.rs
+++ b/src/rust/lqos_node_manager/src/queue_info.rs
@@ -118,14 +118,14 @@ pub async fn flow_stats(ip_list: String, _auth: AuthGuard) -> NoCache<Json<Vec<(
 #[serde(crate = "rocket::serde")]
 pub enum RequestAnalysisResult {
   Fail,
-  Ok(usize)
+  Ok{ session_id: usize, countdown: usize }
 }
 
 #[get("/api/request_analysis/<ip>")]
 pub async fn request_analysis(ip: String) -> NoCache<Json<RequestAnalysisResult>> {
   for r in bus_request(vec![BusRequest::GatherPacketData(ip)]).await.unwrap() {
-    if let BusResponse::PacketCollectionSession(id) = r {
-      return NoCache::new(Json(RequestAnalysisResult::Ok(id)));
+    if let BusResponse::PacketCollectionSession{session_id, countdown} = r {
+      return NoCache::new(Json(RequestAnalysisResult::Ok{session_id, countdown}));
     }
   }
 

--- a/src/rust/lqos_node_manager/static/circuit_queue.html
+++ b/src/rust/lqos_node_manager/static/circuit_queue.html
@@ -608,7 +608,7 @@
             if (analysisTimer > -1) {
                 setTimeout(analyzeTick, 1000);
             } else {
-                window.location.href = "/ip_dump?id=" + analysisId;
+                window.location.href = "/ip_dump?id=" + analysisId + "&circuit_id=" + encodeURI(id);
             }
         }
 

--- a/src/rust/lqos_node_manager/static/circuit_queue.html
+++ b/src/rust/lqos_node_manager/static/circuit_queue.html
@@ -195,7 +195,7 @@
                             <div class="card-body">
                                 <h5 class="card-title"><i class="fa fa-bar-chart"></i> Flows (Last 30 Seconds)</h5>
                                 <p class="alert alert-warning" role="alert">
-                                    <i class="fa fa-warning"></i> Gathering packet data can cause high CPU load during the 10 second capture window.
+                                    <i class="fa fa-warning"></i> Gathering packet data can cause high CPU load during the capture window.
                                 </p>
                                 <div id="packetButtons"></div>
                                 <div id="flowList"></div>
@@ -595,9 +595,9 @@
                     alert("Heimdall is busy serving other customers. Your desire is important to him, please try again later.")
                     return;
                 }
-                analysisId = data.Ok;
+                analysisId = data.Ok.session_id;
                 analysisBtn = "#dumpBtn_" + id;
-                analysisTimer = 10;
+                analysisTimer = data.Ok.countdown;
                 analyzeTick();
             });
         }

--- a/src/rust/lqos_node_manager/static/ip_dump.html
+++ b/src/rust/lqos_node_manager/static/ip_dump.html
@@ -127,7 +127,7 @@ if (hdr->cwr) flags |= 128;
         }
 
         function paginator(active) {
-            let paginator = "<a href='/api/pcap/" + target + "/capture-" + circuit_id + ".pcap' class='btn btn-warning'>Download PCAP Dump</a> ";
+            let paginator = "<a href='/api/pcap/" + target + "/capture-" + circuit_id + "-" + starting_timestamp + ".pcap' class='btn btn-warning'>Download PCAP Dump</a> ";
             paginator += "<a href='#' class='btn btn-info' onClick='zoomIn();'>Zoom In</a> ";
             paginator += "<a href='#' class='btn btn-info' onClick='zoomOut();'>Zoom Out</a> (ℹ️ Or drag an area of the graph) <br />";
 
@@ -198,6 +198,7 @@ if (hdr->cwr) flags |= 128;
         }
 
         let circuit_id = null;
+        let starting_timestamp = null;
 
         function start() {
             colorReloadButton();
@@ -226,6 +227,7 @@ if (hdr->cwr) flags |= 128;
                 }
                 packets = data;
                 pages = Math.ceil((packets.length / PAGE_SIZE));
+                starting_timestamp = min_ts;
                 paginator(0);                
                 viewPage(0);
             });

--- a/src/rust/lqos_node_manager/static/ip_dump.html
+++ b/src/rust/lqos_node_manager/static/ip_dump.html
@@ -127,7 +127,7 @@ if (hdr->cwr) flags |= 128;
         }
 
         function paginator(active) {
-            let paginator = "<a href='/api/pcap/" + target + "/capture.pcap' class='btn btn-warning'>Download PCAP Dump</a> ";
+            let paginator = "<a href='/api/pcap/" + target + "/capture-" + circuit_id + ".pcap' class='btn btn-warning'>Download PCAP Dump</a> ";
             paginator += "<a href='#' class='btn btn-info' onClick='zoomIn();'>Zoom In</a> ";
             paginator += "<a href='#' class='btn btn-info' onClick='zoomOut();'>Zoom Out</a> (ℹ️ Or drag an area of the graph) <br />";
 
@@ -195,7 +195,9 @@ if (hdr->cwr) flags |= 128;
                 {x: x_axis, y:y2_axis, name: 'Upload', type: 'scatter', mode: 'markers', error_x: { type: 'percent', value: capacity[1], symetric: false, valueminus: 0 }},                
             ];
             Plotly.newPlot(graph, data, { margin: { l:0,r:0,b:0,t:0,pad:4 }, yaxis: { automargin: true, title: 'Bytes' }, xaxis: {automargin: true, title: "Nanoseconds"} }, { responsive: true });
-        }        
+        }
+
+        let circuit_id = null;
 
         function start() {
             colorReloadButton();
@@ -203,6 +205,7 @@ if (hdr->cwr) flags |= 128;
             const params = new Proxy(new URLSearchParams(window.location.search), {
                 get: (searchParams, prop) => searchParams.get(prop),
             });
+            circuit_id = params.circuit_id;
 
             capacity = [ params.dn, params.up ]; // Bits per second
             capacity = [ capacity[0] / 8, capacity[1] / 8 ]; // Bytes per second

--- a/src/rust/lqos_node_manager/static/ip_dump.html
+++ b/src/rust/lqos_node_manager/static/ip_dump.html
@@ -23,9 +23,6 @@
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     <li class="nav-item">
-                        <a class="nav-link" href="/"><i class="fa fa-home"></i> Dashboard</a>
-                    </li>
-                    <li class="nav-item">
                         <a class="nav-link" href="/tree?parent=0"><i class="fa fa-tree"></i> Tree</a>
                     </li>
                     <li class="nav-item">

--- a/src/rust/lqosd/src/main.rs
+++ b/src/rust/lqosd/src/main.rs
@@ -18,7 +18,7 @@ use anyhow::Result;
 use log::{info, warn};
 use lqos_bus::{BusRequest, BusResponse, UnixSocketServer};
 use lqos_config::LibreQoSConfig;
-use lqos_heimdall::{ten_second_packet_dump, perf_interface::heimdall_handle_events, start_heimdall};
+use lqos_heimdall::{n_second_packet_dump, perf_interface::heimdall_handle_events, start_heimdall};
 use lqos_queue_tracker::{
   add_watched_queue, get_raw_circuit_data, spawn_queue_monitor,
   spawn_queue_structure_monitor,
@@ -197,16 +197,16 @@ fn handle_bus_requests(
       }
       BusRequest::GetFlowStats(ip) => get_flow_stats(ip),
       BusRequest::GetPacketHeaderDump(id) => {
-        BusResponse::PacketDump(ten_second_packet_dump(*id))
+        BusResponse::PacketDump(n_second_packet_dump(*id))
       }
       BusRequest::GetPcapDump(id) => {
-        BusResponse::PcapDump(lqos_heimdall::ten_second_pcap(*id))
+        BusResponse::PcapDump(lqos_heimdall::n_second_pcap(*id))
       }
       BusRequest::GatherPacketData(ip) => {
         let ip = ip.parse::<IpAddr>();
         if let Ok(ip) = ip {
-          if let Some(id) = lqos_heimdall::hyperfocus_on_target(ip.into()) {
-            BusResponse::PacketCollectionSession(id)
+          if let Some((session_id, countdown)) = lqos_heimdall::hyperfocus_on_target(ip.into()) {
+            BusResponse::PacketCollectionSession{session_id, countdown}
           } else {
             BusResponse::Fail("Busy".to_string())
           }


### PR DESCRIPTION
Issue #291 :

* Make capture time configurable in `/etc/lqos.conf` with the `packet_capture_time` setting. 
* 10 seconds is plenty for "does it work" analysis, and is a nice balance for CPU/RAM/Disk usage, especially on high-volume systems - so 10 seconds remains the default.
* Updates the example `/etc/lqos.conf` file to include the option (again, with a sane default).
* Updates the capture mechanism to no longer hard-code the duration and instead use the specified time.
* Adds circuit ID and starting timestamp to the `pcap` filename, giving an almost-certainly unique download name.

Does not (and will not):

* Add the ending timestamp.
* Add a "stop capture" button, because that would require the addition of inter-thread communication and part of the reason it performs so well is that it operates in an independent fashion.
* Facilitate multiple users running captures at once, because that's an invite to DoS your monitoring server.
