### PR TITLE
Issue 289 - translate  the FwMark String to a TcHandle

### DIFF
--- a/src/rust/lqos_bus/src/tc_handle.rs
+++ b/src/rust/lqos_bus/src/tc_handle.rs
@@ -34,8 +34,13 @@ impl TcHandle {
       "none" => Ok(Self(TC_H_UNSPEC)),
       _ => {
         if !handle.contains(':') {
-          error!("Unable to parse TC handle {handle}. Must contain a colon.");
-          return Err(TcHandleParseError::InvalidInput(handle.to_string()));
+          if let Ok(major) = read_hex_string(handle) {
+            let minor = 0;
+            return Ok(Self((major << 16) | minor));
+          } else {
+            error!("Unable to parse TC handle {handle}. Must contain a colon.");
+            return Err(TcHandleParseError::InvalidInput(handle.to_string()));
+          }
         }
         let parts: Vec<&str> = handle.split(':').collect();        
         let major = read_hex_string(parts[0]).map_err(|_| TcHandleParseError::InvalidInput(handle.to_string()))?;

--- a/src/rust/lqos_queue_tracker/src/queue_types/tc_cake.rs
+++ b/src/rust/lqos_queue_tracker/src/queue_types/tc_cake.rs
@@ -59,7 +59,7 @@ struct TcCakeOptions {
   split_gso: bool,
   raw: bool,
   overhead: u16,
-  fwmark: String,
+  fwmark: TcHandle,
 }
 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
@@ -179,7 +179,7 @@ impl TcCakeOptions {
             "raw" => result.raw = value.as_bool().unwrap_or(false),
             "overhead" => result.overhead = value.as_u64().unwrap_or(0) as u16,
             "fwmark" => {
-              result.fwmark = value.as_str().unwrap_or("").to_string()
+              parse_tc_handle!(result.fwmark, value);
             }
             _ => {
               info_once!(


### PR DESCRIPTION
Parse `fwmark` in Cake stats as a TcHandle
    
FIXES #289

Extend TC parser to handle cases that don't have a colon at all. Use this to parse the `fwmark` field in the Cake stats, which
is probably a TC handle - but since the cake source doesn't document it, it might be a random number for all we know.

The `fwmark` field isn't actually referenced anywhere in the program.