### PR TITLE
UISP Integration Improvements

### DIFF
--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -291,19 +291,14 @@ class NetworkGraph:
 
 		del self.__visited
 		
-		# Child nodes inherit bandwidth maximums of parents. We apply this here to avoid bugs when compression is applied with flattenA().
 		def inheritBandwidthMaxes(data, parentMaxDL, parentMaxUL):
 			for node in data:
 				if isinstance(node, str):
 					if (isinstance(data[node], dict)) and (node != 'children'):
-						# Cap based on this node's max bandwidth, or parent node's max bandwidth, whichever is lower
 						data[node]['downloadBandwidthMbps'] = min(int(data[node]['downloadBandwidthMbps']),int(parentMaxDL))
 						data[node]['uploadBandwidthMbps'] = min(int(data[node]['uploadBandwidthMbps']),int(parentMaxUL))
-						# Recursive call this function for children nodes attached to this node
 						if 'children' in data[node]:
-							# We need to keep tabs on the minor counter, because we can't have repeating class IDs. Here, we bring back the minor counter from the recursive function
 							inheritBandwidthMaxes(data[node]['children'], data[node]['downloadBandwidthMbps'], data[node]['uploadBandwidthMbps'])
-		# Here is the actual call to the recursive function
 		inheritBandwidthMaxes(topLevelNode, parentMaxDL=upstreamBandwidthCapacityDownloadMbps, parentMaxUL=upstreamBandwidthCapacityUploadMbps)
 		
 		with open('network.json', 'w') as f:

--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -2,7 +2,7 @@
 # integrations.
 
 from typing import List, Any
-from ispConfig import allowedSubnets, ignoreSubnets, generatedPNUploadMbps, generatedPNDownloadMbps, circuitNameUseAddress
+from ispConfig import allowedSubnets, ignoreSubnets, generatedPNUploadMbps, generatedPNDownloadMbps, circuitNameUseAddress, upstreamBandwidthCapacityDownloadMbps, upstreamBandwidthCapacityUploadMbps
 import ipaddress
 import enum
 
@@ -290,7 +290,22 @@ class NetworkGraph:
 					child)
 
 		del self.__visited
-
+		
+		# Child nodes inherit bandwidth maximums of parents. We apply this here to avoid bugs when compression is applied with flattenA().
+		def inheritBandwidthMaxes(data, parentMaxDL, parentMaxUL):
+			for node in data:
+				if isinstance(node, str):
+					if (isinstance(data[node], dict)) and (node != 'children'):
+						# Cap based on this node's max bandwidth, or parent node's max bandwidth, whichever is lower
+						data[node]['downloadBandwidthMbps'] = min(int(data[node]['downloadBandwidthMbps']),int(parentMaxDL))
+						data[node]['uploadBandwidthMbps'] = min(int(data[node]['uploadBandwidthMbps']),int(parentMaxUL))
+						# Recursive call this function for children nodes attached to this node
+						if 'children' in data[node]:
+							# We need to keep tabs on the minor counter, because we can't have repeating class IDs. Here, we bring back the minor counter from the recursive function
+							inheritBandwidthMaxes(data[node]['children'], data[node]['downloadBandwidthMbps'], data[node]['uploadBandwidthMbps'])
+		# Here is the actual call to the recursive function
+		inheritBandwidthMaxes(topLevelNode, parentMaxDL=upstreamBandwidthCapacityDownloadMbps, parentMaxUL=upstreamBandwidthCapacityUploadMbps)
+		
 		with open('network.json', 'w') as f:
 			json.dump(topLevelNode, f, indent=4)
 

--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -125,7 +125,7 @@ def buildFullGraph():
 							download = int(download / 2)
 							upload = int(download / 2)
 						if device['identification']['site']['id'] in foundAirFibersBySite:
-							if (download > foundAirFibersBySite['download']) or (upload > foundAirFibersBySite['upload']):
+							if (download > foundAirFibersBySite[device['identification']['site']['id']]['download']) or (upload > foundAirFibersBySite[device['identification']['site']['id']]['upload']):
 								foundAirFibersBySite[device['identification']['site']['id']]['download'] = download
 								foundAirFibersBySite[device['identification']['site']['id']]['upload'] = upload
 						else:


### PR DESCRIPTION
- Use AirFiber backhauls to set site bandwidth limit. If a station mode airfiber serves a site, its bandwidth will be used as a max.
- When using any integration, node max bandwidth will now be limited by that of its parent nodes, preventing confusion on GUI.
- UISP integration now creates integrationUISPbandwidths.template.csv instead of integrationUISPbandwidths.csv. This way it's not constantly overwritten or negatively impacting the ability of the integration to report updated capacities.