### PR TITLE
Last 5 minutes of throughput data are stored server-side on node_manager

### DIFF
--- a/src/rust/lqos_node_manager/src/main.rs
+++ b/src/rust/lqos_node_manager/src/main.rs
@@ -22,11 +22,15 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 #[launch]
 fn rocket() -> _ {
-  //tracker::SHAPED_DEVICES.read().write_csv("ShapedDeviceWriteTest.csv").unwrap();
   let server = rocket::build()
     .attach(AdHoc::on_liftoff("Poll lqosd", |_| {
       Box::pin(async move {
         rocket::tokio::spawn(tracker::update_tracking());
+      })
+    }))
+    .attach(AdHoc::on_liftoff("Poll throughput", |_| {
+      Box::pin(async move {
+        rocket::tokio::spawn(tracker::update_total_throughput_buffer());
       })
     }))
     .register("/", catchers![static_pages::login])
@@ -47,6 +51,7 @@ fn rocket() -> _ {
         static_pages::klingon,
         // API calls
         tracker::current_throughput,
+        tracker::throughput_ring_buffer,
         tracker::cpu_usage,
         tracker::ram_usage,
         tracker::top_10_downloaders,

--- a/src/rust/lqos_node_manager/src/tracker/cache/mod.rs
+++ b/src/rust/lqos_node_manager/src/tracker/cache/mod.rs
@@ -4,6 +4,8 @@
 
 mod cpu_ram;
 mod shaped_devices;
+mod throughput;
 
 pub use cpu_ram::*;
 pub use shaped_devices::*;
+pub use throughput::THROUGHPUT_BUFFER;

--- a/src/rust/lqos_node_manager/src/tracker/cache/throughput.rs
+++ b/src/rust/lqos_node_manager/src/tracker/cache/throughput.rs
@@ -1,0 +1,60 @@
+use crate::tracker::ThroughputPerSecond;
+use lqos_bus::{bus_request, BusRequest, BusResponse};
+use once_cell::sync::Lazy;
+use rocket::tokio::sync::RwLock;
+
+pub static THROUGHPUT_BUFFER: Lazy<RwLock<TotalThroughput>> =
+  Lazy::new(|| RwLock::new(TotalThroughput::new()));
+
+/// Maintains an in-memory ringbuffer of the last 5 minutes of
+/// throughput data.
+pub struct TotalThroughput {
+  data: Vec<ThroughputPerSecond>,
+  head: usize,
+  prev_head: usize,
+}
+
+impl TotalThroughput {
+  /// Create a new throughput ringbuffer system
+  pub fn new() -> Self {
+    Self {
+      data: vec![ThroughputPerSecond::default(); 300],
+      head: 0,
+      prev_head: 0,
+    }
+  }
+
+  /// Run once per second to update the ringbuffer with current data
+  pub async fn tick(&mut self) {
+    if let Ok(messages) =
+      bus_request(vec![BusRequest::GetCurrentThroughput]).await
+    {
+      for msg in messages {
+        if let BusResponse::CurrentThroughput {
+          bits_per_second,
+          packets_per_second,
+          shaped_bits_per_second,
+        } = msg
+        {
+          self.data[self.head].bits_per_second = bits_per_second;
+          self.data[self.head].packets_per_second = packets_per_second;
+          self.data[self.head].shaped_bits_per_second = shaped_bits_per_second;
+          self.prev_head = self.head;
+          self.head += 1;
+          self.head %= 300;
+        }
+      }
+    }
+  }
+
+  /// Retrieve just the current throughput data (1 tick)
+  pub fn current(&self) -> ThroughputPerSecond {
+    self.data[self.prev_head]
+  }
+
+  /// Retrieve the head (0-299) and the full current throughput
+  /// buffer. Used to populate the dashboard the first time.
+  pub fn copy(&self) -> (usize, Vec<ThroughputPerSecond>) {
+    (self.head, self.data.clone())
+  }
+}

--- a/src/rust/lqos_node_manager/src/tracker/mod.rs
+++ b/src/rust/lqos_node_manager/src/tracker/mod.rs
@@ -3,11 +3,11 @@ mod cache_manager;
 use std::net::IpAddr;
 
 use self::cache::{
-  CPU_USAGE, NUM_CPUS, RAM_USED, TOTAL_RAM,
+  CPU_USAGE, NUM_CPUS, RAM_USED, TOTAL_RAM, THROUGHPUT_BUFFER,
 };
 use crate::{auth_guard::AuthGuard, cache_control::NoCache};
 pub use cache::SHAPED_DEVICES;
-pub use cache_manager::update_tracking;
+pub use cache_manager::{update_tracking, update_total_throughput_buffer};
 use lqos_bus::{bus_request, BusRequest, BusResponse, IpStats, TcHandle};
 use rocket::serde::{Deserialize, Serialize, msgpack::MsgPack};
 
@@ -70,23 +70,15 @@ pub struct ThroughputPerSecond {
 pub async fn current_throughput(
   _auth: AuthGuard,
 ) -> NoCache<MsgPack<ThroughputPerSecond>> {
-  let mut result = ThroughputPerSecond::default();
-  if let Ok(messages) =
-    bus_request(vec![BusRequest::GetCurrentThroughput]).await
-  {
-    for msg in messages {
-      if let BusResponse::CurrentThroughput {
-        bits_per_second,
-        packets_per_second,
-        shaped_bits_per_second,
-      } = msg
-      {
-        result.bits_per_second = bits_per_second;
-        result.packets_per_second = packets_per_second;
-        result.shaped_bits_per_second = shaped_bits_per_second;
-      }
-    }
-  }
+  let result = THROUGHPUT_BUFFER.read().await.current();
+  NoCache::new(MsgPack(result))
+}
+
+#[get("/api/throughput_ring_buffer")]
+pub async fn throughput_ring_buffer(
+  _auth: AuthGuard,
+) -> NoCache<MsgPack<(usize, Vec<ThroughputPerSecond>)>> {
+  let result = THROUGHPUT_BUFFER.read().await.copy();
   NoCache::new(MsgPack(result))
 }
 

--- a/src/rust/lqos_node_manager/static/main.html
+++ b/src/rust/lqos_node_manager/static/main.html
@@ -168,6 +168,29 @@
     <script>
         var throughput = new MultiRingBuffer(300);
 
+        // Loads the complete ringbuffer for initial display
+        function fillCurrentThroughput() {
+            msgPackGet("/api/throughput_ring_buffer", (tp) => {
+                console.log(tp);
+                const bits = 0;
+                const packets = 1;
+                const shaped = 2;
+
+                let head = tp[0];
+                for (let i=head; i<300; ++i) {
+                    throughput.push("pps", tp[1][i][packets][0], tp[1][i][packets][1]);
+                    throughput.push("total", tp[1][i][bits][0], tp[1][i][bits][1]);
+                    throughput.push("shaped", tp[1][i][shaped][0], tp[1][i][shaped][1]);
+                }
+                for (let i=0; i<head; ++i) {
+                    throughput.push("pps", tp[1][i][packets][0], tp[1][i][packets][1]);
+                    throughput.push("total", tp[1][i][bits][0], tp[1][i][bits][1]);
+                    throughput.push("shaped", tp[1][i][shaped][0], tp[1][i][shaped][1]);
+                }
+                throughput.plotTotalThroughput("tpGraph");
+            });
+        }
+
         function updateCurrentThroughput() {
             msgPackGet("/api/current_throughput", (tp) => {
                 const bits = 0;
@@ -178,7 +201,7 @@
                 $("#bpsDown").text(scaleNumber(tp[bits][0]));
                 $("#bpsUp").text(scaleNumber(tp[bits][1]));
 
-                throughput.push("pps", tp[1][0], tp[packets][1]);
+                throughput.push("pps", tp[packets][0], tp[packets][1]);
                 throughput.push("total", tp[bits][0], tp[bits][1]);
                 throughput.push("shaped", tp[shaped][0], tp[shaped][1]);
                 throughput.plotTotalThroughput("tpGraph");
@@ -319,7 +342,7 @@
             }
 
             colorReloadButton();
-            updateCurrentThroughput();
+            fillCurrentThroughput();
             updateCpu();
             updateRam();
             updateTop10();


### PR DESCRIPTION
Fixes #317 

Add a server-side ringbuffer for the last 5 minutes of throughput data. This is loaded in full when the dashboard opens, preserving state (and anything missing while you were elsewhere). Subsequent updates query the ringbuffer's most recent value, avoiding downloading large amounts of state.