### PR TITLE
Fix replaceRootNote and circuit stats priorQuery

### DIFF
--- a/old/v1.3/integrationCommon.py
+++ b/old/v1.3/integrationCommon.py
@@ -134,7 +134,7 @@ class NetworkGraph:
                 node.parentId = self.exceptionCPEs[node.displayName]
             self.nodes.append(node)
 
-    def replaceRootNote(self, node: NetworkNode) -> None:
+    def replaceRootNode(self, node: NetworkNode) -> None:
         # Replaces the automatically generated root node
         # with a new node. Useful when you have a top-level
         # node specified (e.g. "uispSite" in the UISP

--- a/old/v1.3/integrationUISP.py
+++ b/old/v1.3/integrationUISP.py
@@ -145,7 +145,7 @@ def buildFullGraph():
         # If this is the uispSite node, it becomes the root. Otherwise, add it to the
         # node soup.
         if name == uispSite:
-            net.replaceRootNote(node)
+            net.replaceRootNode(node)
         else:
             net.addRawNode(node)
 

--- a/old/v1.3/testGraph.py
+++ b/old/v1.3/testGraph.py
@@ -53,7 +53,7 @@ class TestGraph(unittest.TestCase):
         from integrationCommon import NetworkGraph, NetworkNode, NodeType
         graph = NetworkGraph()
         node = NetworkNode("Test", type = NodeType.site)
-        graph.replaceRootNote(node)
+        graph.replaceRootNode(node)
         self.assertEqual(graph.nodes[0].id, "Test")
 
     def add_child_by_named_parent(self):

--- a/src/graphInfluxDB.py
+++ b/src/graphInfluxDB.py
@@ -331,7 +331,7 @@ def getCircuitLatencyStats(subscriberCircuits):
 			# If we can't identify RTT this time around, use most recently recorded RTT
 			# None by default, change if found in priorQuery
 			circuit['stats']['sinceLastQuery']['tcpLatency'] = None
-			if circuit['stats']['priorQuery'] != None:
+			if 'priorQuery' in circuit['stats'] and circuit['stats']['priorQuery'] != None:
 				if 'priorQuery' in circuit['stats']:
 					if 'tcpLatency' in circuit['stats']['priorQuery']:
 						circuit['stats']['sinceLastQuery']['tcpLatency'] = circuit['stats']['priorQuery']['tcpLatency']

--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -135,7 +135,7 @@ class NetworkGraph:
 				node.parentId = self.exceptionCPEs[node.displayName]
 			self.nodes.append(node)
 
-	def replaceRootNote(self, node: NetworkNode) -> None:
+	def replaceRootNode(self, node: NetworkNode) -> None:
 		# Replaces the automatically generated root node
 		# with a new node. Useful when you have a top-level
 		# node specified (e.g. "uispSite" in the UISP

--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -176,7 +176,7 @@ def buildFullGraph():
 		# If this is the uispSite node, it becomes the root. Otherwise, add it to the
 		# node soup.
 		if name == uispSite:
-			net.replaceRootNote(node)
+			net.replaceRootNode(node)
 		else:
 			net.addRawNode(node)
 

--- a/src/testGraph.py
+++ b/src/testGraph.py
@@ -53,7 +53,7 @@ class TestGraph(unittest.TestCase):
         from integrationCommon import NetworkGraph, NetworkNode, NodeType
         graph = NetworkGraph()
         node = NetworkNode("Test", type = NodeType.site)
-        graph.replaceRootNote(node)
+        graph.replaceRootNode(node)
         self.assertEqual(graph.nodes[0].id, "Test")
 
     def add_child_by_named_parent(self):


### PR DESCRIPTION
Two small fixes:
- replaceRootNote should be replaceRootNode
- To prevent exception on first run of getCircuitLatencyStats in graphInfluxDB.py, we should check that priorQuery exists before using it