### PR TITLE
Fix displayed plans in Top/Worst N tables

### DIFF
--- a/src/rust/lqos_node_manager/src/tracker/mod.rs
+++ b/src/rust/lqos_node_manager/src/tracker/mod.rs
@@ -50,7 +50,7 @@ impl From<&IpStats> for IpStatsWithPlan {
           &circuit.circuit_name
         };
         result.ip_address = format!("{} ({})", name, result.ip_address);
-        result.plan = (circuit.download_max_mbps, circuit.download_min_mbps);
+        result.plan = (circuit.download_max_mbps, circuit.upload_max_mbps);
       }
     }
 

--- a/src/rust/lqos_node_manager/static/main.html
+++ b/src/rust/lqos_node_manager/static/main.html
@@ -171,7 +171,7 @@
         // Loads the complete ringbuffer for initial display
         function fillCurrentThroughput() {
             msgPackGet("/api/throughput_ring_buffer", (tp) => {
-                console.log(tp);
+                //console.log(tp);
                 const bits = 0;
                 const packets = 1;
                 const shaped = 2;


### PR DESCRIPTION
A value was transposed in the IPStats to IPStats transit conversion. The UI now displays (max download/max upload) correctly.

Fix an accidental inclusion of a console.log statement logging needlessly.