### PR TITLE
Uisp integration enhancements: Topology

### DIFF
--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -383,6 +383,10 @@ class NetworkGraph:
 						#Remove brackets and quotes of list so LibreQoS.py can parse it
 						device["ipv4"] = str(device["ipv4"]).replace('[','').replace(']','').replace("'",'')
 						device["ipv6"] = str(device["ipv6"]).replace('[','').replace(']','').replace("'",'')
+						if circuit["upload"] is None: 
+							circuit["upload"] = 0.0
+						if circuit["download"] is None: 
+							circuit["download"] = 0.0
 						row = [
 							circuit["id"],
 							circuit["name"],
@@ -392,10 +396,10 @@ class NetworkGraph:
 							device["mac"],
 							device["ipv4"],
 							device["ipv6"],
-							int(circuit["download"] * 0.98),
-							int(circuit["upload"] * 0.98),
-							int(circuit["download"] * bandwidthOverheadFactor),
-							int(circuit["upload"] * bandwidthOverheadFactor),
+							int(float(circuit["download"]) * 0.98),
+							int(float(circuit["upload"]) * 0.98),
+							int(float(circuit["download"]) * bandwidthOverheadFactor),
+							int(float(circuit["upload"]) * bandwidthOverheadFactor),
 							""
 						]
 						wr.writerow(row)

--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -418,7 +418,7 @@ class NetworkGraph:
 
 		import graphviz
 		dot = graphviz.Digraph(
-			'network', comment="Network Graph", engine="fdp")
+			'network', comment="Network Graph", engine="dot")
 
 		for (i, node) in enumerate(self.nodes):
 			if ((node.type != NodeType.client and node.type != NodeType.device) or showClients):

--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -118,8 +118,12 @@ def buildFullGraph():
 			if device['identification']['role'] == "station":
 				if device['identification']['type'] == "airFiber":
 					if device['overview']['status'] == 'active':
-						download = int(device['overview']['downlinkCapacity']/ 1000000)
-						upload = int(device['overview']['uplinkCapacity']/ 1000000)
+						if device['overview']['downlinkCapacity'] is not None and device['overview']['uplinkCapacity'] is not None:
+							download = int(device['overview']['downlinkCapacity']/ 1000000)
+							upload = int(device['overview']['uplinkCapacity']/ 1000000)
+						else:
+							download = generatedPNDownloadMbps
+							upload = generatedPNUploadMbps
 						# Make sure to use half of reported bandwidth for AF60-LRs
 						if device['identification']['model'] == "AF60-LR":
 							download = int(download / 2)

--- a/src/integrationUISProutes.csv
+++ b/src/integrationUISProutes.csv
@@ -1,0 +1,5 @@
+# Allows you to override route costs in the UISP integration, to better
+# represent your network. Costs by default increment 10 at each hop.
+# So if you want to skip 10 links, put a cost of 100 in.
+# From Site Name, To Site Name, New Cost
+# MYCORE, MYTOWER, 100


### PR DESCRIPTION
Replace the UISP network.json generator that previously used UISP's "parent" nodes to determine tree position with a full cost-based spanning tree (Dijkstra). This makes multi-homed networks easier to manage, by specifying a root position other than the "natural" route and regenerating the entire tree relative to this node location. So flipping `A->B->C->D` to be `D->C->B->A` works well, as does `B->A, B->C->D`.

The second half adds a file named `integrationUISProutes.csv`. It contains "from", "to" and "cost" fields. When the tree builder finds a route "from->to", it uses the cost specified in this file. This allows you to override behavior, for example if you have `A->B->C` and *also* have `A->C` but don't want `A->C` to be the default - you can specify a high cost (say 100) for `A->C`.

For example, given the following topology:
```mermaid
graph LR
    A-->B
    B-->C
    C-->D
```

You could change the root to be D and have:
```mermaid
graph LR
    D-->C
    C-->B
    B-->A
```

Given a more complex hierarchy:
```mermaid
graph LR
    D-->C
    C-->B
    B-->A
    D-->A
```

One could enter a row in  `integrationUISProutes.csv`:
```csv
D, A, 100
```

And the shorter D->A route would be ignored:

```mermaid
graph LR
    D-->C
    C-->B
    B-->A
    D--Ignored-->A
```