### PR TITLE
Handle sites branched off PtMP Access Points

### DIFF
--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -285,8 +285,13 @@ def buildFullGraph():
 				if link['from']['site']['identification']['id'] == parent:
 					if link['to']['site']['identification']['id'] == id:
 						if link['from']['device']['overview']['wirelessMode'] == 'ap-ptmp':
-							nodeOffPtMP[id] = link['from']['device']['identification']['id']
-	
+							# Capacity of the PtMP client radio feeding the PoP will be used as the site bandwidth limit
+							download = int(round(link['to']['device']['overview']['downlinkCapacity']/1000000))
+							upload = int(round(link['to']['device']['overview']['uplinkCapacity']/1000000))
+							nodeOffPtMP[id] = { 'parent': link['from']['device']['identification']['id'],
+												'download': download,
+												'upload': upload
+												}
 	print("Building Topology")
 	net = NetworkGraph()
 	# Add all sites and client sites
@@ -308,11 +313,14 @@ def buildFullGraph():
 			case "site":
 				nodeType = NodeType.site
 				if id in nodeOffPtMP:
-					parent = nodeOffPtMP[id]
+					parent = nodeOffPtMP[id]['parent']
 				if name in siteBandwidth:
 					# Use the CSV bandwidth values
 					download = siteBandwidth[name]["download"]
 					upload = siteBandwidth[name]["upload"]
+				elif id in nodeOffPtMP:
+					download = nodeOffPtMP[id]['download']
+					upload = nodeOffPtMP[id]['upload']
 				elif id in foundAirFibersBySite:
 					download = foundAirFibersBySite[id]['download']
 					upload = foundAirFibersBySite[id]['upload']

--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -272,7 +272,21 @@ def buildFullGraph():
 	# 	else:
 	# 		p = findInSiteListById(siteList, s['parent'])['name']
 	# 		print(s['name'] + " (" + str(s['cost']) + ") <-- " + p)
-
+	
+	# Find Nodes Connected By PtMP
+	nodeOffPtMP = {}
+	for site in sites:
+		id = site['identification']['id']
+		name = site['identification']['name']
+		type = site['identification']['type']
+		parent = findInSiteListById(siteList, id)['parent']
+		if type == 'site':
+			for link in dataLinks:
+				if link['from']['site']['identification']['id'] == parent:
+					if link['to']['site']['identification']['id'] == id:
+						if link['from']['device']['overview']['wirelessMode'] == 'ap-ptmp':
+							nodeOffPtMP[id] = link['from']['device']['identification']['id']
+	
 	print("Building Topology")
 	net = NetworkGraph()
 	# Add all sites and client sites
@@ -293,6 +307,8 @@ def buildFullGraph():
 		match type:
 			case "site":
 				nodeType = NodeType.site
+				if id in nodeOffPtMP:
+					parent = nodeOffPtMP[id]
 				if name in siteBandwidth:
 					# Use the CSV bandwidth values
 					download = siteBandwidth[name]["download"]
@@ -365,7 +381,7 @@ def buildFullGraph():
 									# Add some defaults in case they want to change them
 									siteBandwidth[node.displayName] = {
 										"download": generatedPNDownloadMbps, "upload": generatedPNUploadMbps}
-
+	
 	net.prepareTree()
 	net.plotNetworkGraph(False)
 	if net.doesNetworkJsonExist():


### PR DESCRIPTION
There are a handful of cases in our network where a Micro-PoP is established off a PtMP Access Point. Previously, the UISP Integration placed those as nodes of the site above, but not as nodes of the PtMP access point. That meant the capacity of the PtMP access point was sort of ignored, and overages could theoretically occur. This change fixes that.