### PR TITLE
UISP Handle Multiple Internet-Connected Sites

### DIFF
--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -370,8 +370,6 @@ def buildFullGraph():
 		match type:
 			case "site":
 				nodeType = NodeType.site
-				if id in nodeOffPtMP:
-					parent = nodeOffPtMP[id]['parent']
 				if name in siteBandwidth:
 					# Use the CSV bandwidth values
 					download = siteBandwidth[name]["download"]
@@ -381,13 +379,13 @@ def buildFullGraph():
 					if id in foundAirFibersBySite:
 						download = foundAirFibersBySite[id]['download']
 						upload = foundAirFibersBySite[id]['upload']
-						#print('Site ' + name + ' will use bandwidth from foundAirFibersBySite.')
-					# Use limits from nodeOffPtMP only if they're greater than what is already set
-					if id in nodeOffPtMP:
-						if (nodeOffPtMP[id]['download'] >= download) or (nodeOffPtMP[id]['upload'] >= upload):
-							download = nodeOffPtMP[id]['download']
-							upload = nodeOffPtMP[id]['upload']
-							#print('Site ' + name + ' will use bandwidth from nodeOffPtMP.')
+					# If no airFibers were found, and node originates off PtMP, treat as child node of that PtMP AP
+					else:
+						if id in nodeOffPtMP:
+							if (nodeOffPtMP[id]['download'] >= download) or (nodeOffPtMP[id]['upload'] >= upload):
+								download = nodeOffPtMP[id]['download']
+								upload = nodeOffPtMP[id]['upload']
+					
 				siteBandwidth[name] = {
 						"download": download, "upload": upload}
 			case default:

--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -287,7 +287,7 @@ def buildFullGraph():
 	# Attempts to build a full network graph, incorporating as much of the UISP
 	# hierarchy as possible.
 	from integrationCommon import NetworkGraph, NetworkNode, NodeType
-	from ispConfig import generatedPNUploadMbps, generatedPNDownloadMbps
+	from ispConfig import uispSite, generatedPNUploadMbps, generatedPNDownloadMbps
 
 	# Load network sites
 	print("Loading Data from UISP")

--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -295,6 +295,26 @@ def buildFullGraph():
 	devices = uispRequest("devices?withInterfaces=true&authorized=true")
 	dataLinks = uispRequest("data-links?siteLinksOnly=true")
 
+	# If multiple Internet-connected sites, create Internet root node:
+	internetConnectedSites = []
+	for link in dataLinks:
+		if link['canDelete'] ==  False:
+			if link['from']['device']['identification']['id'] == link['to']['device']['identification']['id']:
+				siteID = link['from']['site']['identification']['id']
+				# Found internet link
+				internetConnectedSites.append(siteID)
+	if len(internetConnectedSites) > 1:
+		internetSite = {'id': '001', 'identification': {'id': '001', 'status': 'active', 'name': 'Internet', 'parent': None, 'type': 'site'}}
+		sites.append(internetSite)
+		uispSite = 'Internet'
+		for link in dataLinks:
+			if link['canDelete'] ==  False:
+				if link['from']['device']['identification']['id'] == link['to']['device']['identification']['id']:
+					link['from']['site']['identification']['id'] = '001'
+					link['from']['site']['identification']['name'] = 'Internet'
+					# Found internet link
+					internetConnectedSites.append(siteID)
+	
 	# Build Site Capacities
 	print("Compiling Site Bandwidths")
 	siteBandwidth = buildSiteBandwidths()

--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -283,19 +283,7 @@ def findNodesBranchedOffPtMP(siteList, dataLinks, sites, rootSite):
 																		}
 	return nodeOffPtMP
 
-def buildFullGraph():
-	# Attempts to build a full network graph, incorporating as much of the UISP
-	# hierarchy as possible.
-	from integrationCommon import NetworkGraph, NetworkNode, NodeType
-	from ispConfig import uispSite, generatedPNUploadMbps, generatedPNDownloadMbps
-
-	# Load network sites
-	print("Loading Data from UISP")
-	sites = uispRequest("sites")
-	devices = uispRequest("devices?withInterfaces=true&authorized=true")
-	dataLinks = uispRequest("data-links?siteLinksOnly=true")
-
-	# If multiple Internet-connected sites, create Internet root node:
+def handleMultipleInternetNodes(sites, dataLinks, uispSite):
 	internetConnectedSites = []
 	for link in dataLinks:
 		if link['canDelete'] ==  False:
@@ -314,6 +302,22 @@ def buildFullGraph():
 					link['from']['site']['identification']['name'] = 'Internet'
 					# Found internet link
 					internetConnectedSites.append(siteID)
+	return(sites, dataLinks, uispSite)
+
+def buildFullGraph():
+	# Attempts to build a full network graph, incorporating as much of the UISP
+	# hierarchy as possible.
+	from integrationCommon import NetworkGraph, NetworkNode, NodeType
+	from ispConfig import uispSite, generatedPNUploadMbps, generatedPNDownloadMbps
+
+	# Load network sites
+	print("Loading Data from UISP")
+	sites = uispRequest("sites")
+	devices = uispRequest("devices?withInterfaces=true&authorized=true")
+	dataLinks = uispRequest("data-links?siteLinksOnly=true")
+
+	# If multiple Internet-connected sites, create Internet root node:
+	sites, dataLinks, uispSite = handleMultipleInternetNodes(sites, dataLinks, uispSite)
 	
 	# Build Site Capacities
 	print("Compiling Site Bandwidths")


### PR DESCRIPTION
For cases where there are multiple internet-connected top level sites, this change will create an 'Internet' node and place every top level site under that.

```mermaid
  graph TD;
      Internet-->SiteA;
      Internet-->SiteB;
      Internet-->SiteC;
```