### PR TITLE
Fix scheduler concurrence issues

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -12,8 +12,9 @@ if automaticImportUISP:
 if automaticImportSplynx:
 	from integrationSplynx import importFromSplynx
 from apscheduler.schedulers.background import BlockingScheduler
+from apscheduler.executors.pool import ThreadPoolExecutor
 
-ads = BlockingScheduler()
+ads = BlockingScheduler(executors={'default': ThreadPoolExecutor(1)})
 
 def importFromCRM():
 	if automaticImportUISP:
@@ -48,9 +49,9 @@ def importAndShapePartialReload():
 if __name__ == '__main__':
 	importAndShapeFullReload()
 
-	ads.add_job(importAndShapePartialReload, 'interval', minutes=queueRefreshIntervalMins)
+	ads.add_job(importAndShapePartialReload, 'interval', minutes=queueRefreshIntervalMins, max_instances=1)
 
 	if influxDBEnabled:
-		ads.add_job(graphHandler, 'interval', seconds=10)
+		ads.add_job(graphHandler, 'interval', seconds=10, max_instances=1)
 
 	ads.start()


### PR DESCRIPTION
This limits [concurrent tasks](https://stackoverflow.com/questions/35185829/only-run-one-job-concurrently-in-apscheduler-across-the-same-scheduler) within the scheduler to 1, and max instances of importAndShapePartialReload and graphHandler to 1. This is in an effort to avoid race conditions.