### PR TITLE
Correct airMax capacities

### DIFF
--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -10,6 +10,10 @@ try:
 except:
 	from ispConfig import uispSite, uispStrategy
 	overwriteNetworkJSONalways = False
+try:
+	from ispConfig import airMax_capacity
+except:
+	airMax_capacity = 0.65
 
 def uispRequest(target):
 	# Sends an HTTP request to UISP and returns the
@@ -136,6 +140,9 @@ def findApCapacities(devices, siteBandwidth):
 				download = int(device['overview']
 							   ['downlinkCapacity'] / 1000000)
 				upload = int(device['overview']['uplinkCapacity'] / 1000000)
+				dlRatio = None
+				if device['identification']['type'] == 'airMax':
+					download, upload = airMaxCapacityCorrection(device, download, upload)
 				if (download < 15) or (upload < 15):
 					print("WARNING: Device '" + device['identification']['hostname'] + "' has unusually low capacity (" + str(download) + '/' + str(upload) + " Mbps). Discarding in favor of parent site rates.")
 					safeToUse = False
@@ -147,6 +154,29 @@ def findApCapacities(devices, siteBandwidth):
 					siteBandwidth[device['identification']['name']] = {
 						"download": download, "upload": upload}
 
+def airMaxCapacityCorrection(device, download, upload):
+	dlRatio = None
+	for interface in device['interfaces']:
+		if ('wireless' in interface) and (interface['wireless'] != None):
+			if 'dlRatio' in interface['wireless']:
+				dlRatio = interface['wireless']['dlRatio']
+	# UISP reports unrealistically high capacities for airMax.
+	# For fixed frame, multiply capacity by the ratio for download/upload.
+	# For Flexible Frame, use 65% of reported capcity.
+	# 67/33
+	if dlRatio == 67:
+		download = download * 0.67
+		upload = upload * 0.33
+	# 50/50
+	elif dlRatio == 50:
+		download = download * 0.50
+		upload = upload * 0.50
+	# Flexible frame
+	elif dlRatio == None:
+		download = download * airMax_capacity
+		upload = upload * airMax_capacity
+	return (download, upload)
+
 def findAirfibers(devices, generatedPNDownloadMbps, generatedPNUploadMbps):
 	foundAirFibersBySite = {}
 	for device in devices:
@@ -157,6 +187,9 @@ def findAirfibers(devices, generatedPNDownloadMbps, generatedPNUploadMbps):
 						if device['overview']['downlinkCapacity'] is not None and device['overview']['uplinkCapacity'] is not None:
 							download = int(device['overview']['downlinkCapacity']/ 1000000)
 							upload = int(device['overview']['uplinkCapacity']/ 1000000)
+							# Correct AirMax Capacities
+							if device['identification']['type'] == 'airMax':
+								download, upload = airMaxCapacityCorrection(device, download, upload)
 							# Make sure to factor in gigabit port for AF60/AF60-LRs
 							if (device['identification']['model'] == "AF60-LR") or (device['identification']['model'] == "AF60"):
 								download = min(download,950)

--- a/src/ispConfig.example.py
+++ b/src/ispConfig.example.py
@@ -97,6 +97,9 @@ uispSite = ''
 #   or site options.
 # * "full" - build a complete network map
 uispStrategy = "full"
+# Assumed capacity of airMax radios vs reported capacity by UISP. For example, 65% would be 0.65
+# Applies to flexible frame only. Fixed frame will have capacity based on its ratio.
+airMax_capacity = 0.65
 # List any sites that should not be included, with each site name surrounded by '' and separated by commas
 excludeSites = []
 # If you use IPv6, this can be used to find associated IPv6 prefixes for your clients' IPv4 addresses, and match them


### PR DESCRIPTION
If an airmax device uses fixed frame, its capacity is the UISP reported capacity X its download/upload ratio.
If an airmax device uses flexible frame, its capacity is the UISP reported capacity X airMax_capacity (defined in ispConfig.py)