### PR TITLE
Validate network #374 

### DIFF
--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -149,6 +149,8 @@ class NetworkGraph:
 		if not node.displayName in self.excludeSites:
 			if node.displayName in self.exceptionCPEs.keys():
 				node.parentId = self.exceptionCPEs[node.displayName]
+
+			# Checking the correctness of parent/children relationship before adding a node
 			if self.validateParentChildren(node):
 				self.nodes.append(node)
 			else:
@@ -216,14 +218,15 @@ class NetworkGraph:
 
 	def validateParentChildren(self, node:NetworkNode) -> bool:
 		parentIndex = self.findNodeIndexById(node.parentId)
-		# parent is set to null 
+		# parent is set to null or currently does not exist. Ignoring the case that parent does not exist to not make any
+		# conflict with integratoionUISP.py and integrationSpylnx.py. 
 		if parentIndex == -1:
 			return True 
 		
 		parentType = self.nodes[parentIndex].type
 
 		# Each device should have a client as parent 
-		if node.type== NodeType.device and parentType !=NodeType.client:
+		if node.type == NodeType.device and parentType != NodeType.client:
 			return False
 
 		# Each client or clientWithChildren should have ap, site or clientWithChildren as parent
@@ -232,11 +235,11 @@ class NetworkGraph:
 				return False
 		
 		if node.type == NodeType.ap or node.type == NodeType.site:
-			if parentType != NodeType.site or parentType !=NodeType.root:
+			if parentType != NodeType.site or parentType != NodeType.root:
 				return False 
 			
 		# Checking the root node type having no parent
-		if node.type == NodeType.root and parentType != "":
+		if node.type == NodeType.root and node.parentId != "":
 			return False
 		
 		return True 

--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -235,7 +235,7 @@ class NetworkGraph:
 				return False
 		
 		if node.type == NodeType.ap or node.type == NodeType.site:
-			if parentType != NodeType.site or parentType != NodeType.root:
+			if not (parentType == NodeType.site or parentType == NodeType.root):
 				return False 
 			
 		# Checking the root node type having no parent


### PR DESCRIPTION
Another fix of issue #374 :

**Fixes:**

* Checking the correctness of parent/children relationship before adding a node to networks 
*  Relationship criteria:
   * Device should have parent node as client(customer)
   * Client and clientWithChildren should have AS or Site or root as parent
   * AS and site should have site or root as parent
   * Root node should not have any parent 
* At first, we look for the parentID of the new node and then extract the type of parentID
   * If the parentID does not exist(no parent specified), it would be directly assigned to the queue (like flat network)
   * If the parentID does not exist(specified but no node in the network has that ID), it should be also checked. If we add the nodes to the network in top-down approach, that would be fine. Otherwise, for the sake of correctness, we should check this parent/children validation after inserting all of the element into the network. 

