### PR TITLE
Fix bug in mikrotikFindIPv6.py

### DIFF
--- a/src/mikrotikFindIPv6.py
+++ b/src/mikrotikFindIPv6.py
@@ -35,10 +35,15 @@ def pullMikrotikIPv6():
 		list_binding6 = api.get_resource('/ipv6/dhcp-server/binding')
 		entries = list_binding6.get()
 		for entry in entries:
-			try:
-				clientAddressToIPv6[entry['client-address']] = entry['address']
-			except:
-				pass
+			if len(entry['duid']) ==  14:
+				mac = entry['duid'][2:14].upper()
+				macNew = mac[0:2] + ':' + mac[2:4] + ':' + mac[4:6] + ':' + mac[6:8] + ':' + mac[8:10] + ':' + mac[10:12]
+				macToIPv6[macNew] = entry['address']
+			else:
+				try:
+					clientAddressToIPv6[entry['client-address']] = entry['address']
+				except:
+					pass
 		list_neighbor6 = api.get_resource('/ipv6/neighbor')
 		entries = list_neighbor6.get()
 		for entry in entries:


### PR DESCRIPTION
Previously, some CPE IPv6 addresses were not correctly associated with the IPv4 MAC. This fixes that.