### PR TITLE
Fix UISP Integration Bug - Disconnected Sites Should Still Be Shaped

### DIFF
--- a/src/integrationUISP.py
+++ b/src/integrationUISP.py
@@ -479,7 +479,6 @@ def buildFullGraph():
 
 				if site['identification']['status'] == "disconnected":
 					print("WARNING: Site " + name + " is disconnected")
-					continue
 
 		node = NetworkNode(id=id, displayName=name, type=nodeType,
 						   parentId=parent, download=download, upload=upload, address=address, customerName=customerName)


### PR DESCRIPTION
Previously, when a client radio was disconnected, the site would be considered disconnected, and in turn be unshaped.
This led to situations where, if a client radio was temporarily disconnected or rebooted, the client router would remain unshaped until the next run of lqos_scheduler. This could potentially lead to traffic exceeding AP/site/node limits for brief periods of time.

To correct this, the UISP integration will now shape all sites, even those considered disconnected.