### PR TITLE
Preflight checks for lqosd

### DIFF
--- a/src/rust/lqos_sys/src/lib.rs
+++ b/src/rust/lqos_sys/src/lib.rs
@@ -30,3 +30,4 @@ pub use linux::num_possible_cpus;
 pub use lqos_kernel::max_tracked_ips;
 pub use throughput::{throughput_for_each, HostCounter};
 pub use bpf_iterator::{iterate_flows, end_flows};
+pub use lqos_kernel::interface_name_to_index;

--- a/src/rust/lqos_sys/src/lqos_kernel.rs
+++ b/src/rust/lqos_sys/src/lqos_kernel.rs
@@ -37,6 +37,13 @@ pub fn check_root() -> Result<()> {
   }
 }
 
+/// Converts an interface name to an interface index.
+/// This is a wrapper around the `if_nametoindex` function.
+/// Returns an error if the interface does not exist.
+/// # Arguments
+/// * `interface_name` - The name of the interface to convert
+/// # Returns
+/// * The index of the interface
 pub fn interface_name_to_index(interface_name: &str) -> Result<u32> {
   let if_name = CString::new(interface_name)?;
   let index = unsafe { if_nametoindex(if_name.as_ptr()) };

--- a/src/rust/lqosd/src/main.rs
+++ b/src/rust/lqosd/src/main.rs
@@ -32,6 +32,7 @@ use stats::{BUS_REQUESTS, TIME_TO_POLL_HOSTS, HIGH_WATERMARK_DOWN, HIGH_WATERMAR
 use throughput_tracker::flow_data::get_rtt_events_per_second;
 use tokio::join;
 mod stats;
+mod preflight_checks;
 
 // Use JemAllocator only on supported platforms
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -56,7 +57,15 @@ async fn main() -> Result<()> {
   }
 
   info!("LibreQoS Daemon Starting");
+  
+  // Run preflight checks
+  preflight_checks::preflight_checks()?;
+
+  // Load config
   let config = lqos_config::load_config()?;
+
+  
+  // Apply Tunings
   tuning::tune_lqosd_from_config_file()?;
 
   // Start the XDP/TC kernels

--- a/src/rust/lqosd/src/preflight_checks.rs
+++ b/src/rust/lqosd/src/preflight_checks.rs
@@ -1,0 +1,84 @@
+use std::path::Path;
+
+use anyhow::Result;
+use log::{error, info};
+use lqos_sys::interface_name_to_index;
+
+fn check_queues(interface: &str) -> Result<()> {
+    let path = format!("/sys/class/net/{interface}/queues/");
+    let sys_path = Path::new(&path);
+    if !sys_path.exists() {
+        error!("/sys/class/net/{interface}/queues/ does not exist. Does this card only support one queue (not supported)?");
+        return Err(anyhow::anyhow!("/sys/class/net/{interface}/queues/ does not exist. Does this card only support one queue (not supported)?"));
+    }
+
+    let mut counts = (0, 0);
+    let paths = std::fs::read_dir(sys_path)?;
+    for path in paths {
+        if let Ok(path) = &path {
+            if path.path().is_dir() {
+                if let Some(filename) = path.path().file_name() {
+                    if let Some(filename) = filename.to_str() {
+                        if filename.starts_with("rx-") {
+                            counts.0 += 1;
+                        } else if filename.starts_with("tx-") {
+                            counts.1 += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if counts.0 == 0 || counts.1 == 0 {
+        error!("Interface ({}) does not have both RX and TX queues.", interface);
+        return Err(anyhow::anyhow!("Interface {} does not have both RX and TX queues.", interface));
+    }
+    if counts.0 == 1 || counts.1 == 1 {
+        error!("Interface ({}) only has one RX or TX queue. This is not supported.", interface);
+        return Err(anyhow::anyhow!("Interface {} only has one RX or TX queue. This is not supported.", interface));
+    }
+
+    Ok(())
+}
+
+/// Runs a series of preflight checks to ensure that the configuration is sane
+pub fn preflight_checks() -> Result<()> {
+    info!("Sanity checking configuration...");
+
+    // Are we able to load the configuration?
+    let config = lqos_config::load_config().map_err(|_| {
+        error!("Failed to load configuration file - /etc/lqos.conf");
+        anyhow::anyhow!("Failed to load configuration file")
+    })?;
+
+    // Do the interfaces exist?
+    if config.on_a_stick_mode() {
+        interface_name_to_index(&config.internet_interface()).map_err(|_| {
+            error!(
+                "Interface ({}) does not exist.",
+                config.internet_interface()
+            );
+            anyhow::anyhow!("Interface {} does not exist", config.internet_interface())
+        })?;
+        check_queues(&config.internet_interface())?;
+    } else {
+        interface_name_to_index(&config.internet_interface()).map_err(|_| {
+            error!(
+                "Interface ({}) does not exist.",
+                config.internet_interface()
+            );
+            anyhow::anyhow!("Interface {} does not exist", config.internet_interface())
+        })?;
+        interface_name_to_index(&config.isp_interface()).map_err(|_| {
+            error!("Interface ({}) does not exist.", config.isp_interface());
+            anyhow::anyhow!("Interface {} does not exist", config.isp_interface())
+        })?;
+        check_queues(&config.internet_interface())?;
+        check_queues(&config.isp_interface())?;
+    }
+
+    info!("Sanity checks passed");
+
+    Ok(())
+}


### PR DESCRIPTION
Adds an automatic check for the following common issues on startup:

* Unable to load configuration (bail if it is unreadable and not portable)
* Check that interfaces referenced actually exist, bail out with a nice message if they don't.
* Check that interfaces referenced have more than 1 RX/TX queue - bail out with a nice message if they don't.
