### PR TITLE
Lts cake import2

### DIFF
--- a/src/rust/lts_client/src/collector/quick_drops/retriever.rs
+++ b/src/rust/lts_client/src/collector/quick_drops/retriever.rs
@@ -93,8 +93,15 @@ impl AsyncQueueReader {
                                         if let Some(serde_json::Value::Number(drops)) = map.get("drops") {
                                             stats.drops = drops.as_u64().unwrap_or(0);
                                         }
-                                        if let Some(serde_json::Value::Number(marks)) = map.get("ecn_mark") {
-                                            stats.marks = marks.as_u64().unwrap_or(0);
+                                        if let Some(serde_json::Value::Array(tins)) = map.get("tins") {
+                                            stats.marks = 0;
+                                            for tin in tins.iter() {
+                                                if let Some(tin) = tin.as_object() {
+                                                    if let Some(serde_json::Value::Number(marks)) = tin.get("ecn_mark") {
+                                                        stats.marks += marks.as_u64().unwrap_or(0);
+                                                    }
+                                                }
+                                            }
                                         }
                                         result.push(stats);
                                     }

--- a/src/rust/lts_client/src/collector/quick_drops/stats_diff.rs
+++ b/src/rust/lts_client/src/collector/quick_drops/stats_diff.rs
@@ -90,7 +90,11 @@ impl CakeTracker {
             up.retain(|u| u.drops > 0 || u.marks > 0);
             down.retain(|d| d.drops > 0 || d.marks > 0);
 
-            Some((up, down))
+            if up.is_empty() && down.is_empty() {
+                None
+            } else {
+                Some((up, down))
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes the currently broken LTS Cake queue stats exporter:

* ECN Marks were being gathered incorrectly, leading to the false assumption that there weren't any the majority of the time.
* Zero drop/mark events were being reported, significantly bloating the output.
* Significantly reduced the frequency of the queue poll, because it has a regular impact on CPU and was sending far too much data.

*This is a draft pull request, I didn't mean to request review yet - wanted to make sure the issue and progress was logged.*