### PR TITLE
Xdp hot cache

### DIFF
--- a/src/rust/lqos_node_manager/src/tracker/cache_manager.rs
+++ b/src/rust/lqos_node_manager/src/tracker/cache_manager.rs
@@ -121,8 +121,7 @@ fn watch_for_shaped_devices_changing() -> Result<()> {
 pub async fn update_total_throughput_buffer() {
   loop {
     let now = Instant::now();
-    let mut lock = THROUGHPUT_BUFFER.write().await;
-    lock.tick().await;
+    THROUGHPUT_BUFFER.tick().await;
     let wait_time = Duration::from_secs(1) - now.elapsed();
     if wait_time.as_micros() > 0 {
       rocket::tokio::time::sleep(Duration::from_secs(1)).await;

--- a/src/rust/lqos_node_manager/src/tracker/cache_manager.rs
+++ b/src/rust/lqos_node_manager/src/tracker/cache_manager.rs
@@ -122,9 +122,9 @@ pub async fn update_total_throughput_buffer() {
   loop {
     let now = Instant::now();
     THROUGHPUT_BUFFER.tick().await;
-    let wait_time = Duration::from_secs(1) - now.elapsed();
-    if wait_time.as_micros() > 0 {
-      rocket::tokio::time::sleep(Duration::from_secs(1)).await;
+    let elapsed = now.elapsed();
+    if elapsed < Duration::from_secs(1) {
+      rocket::tokio::time::sleep(Duration::from_secs(1) - elapsed).await;
     }
   }
 }

--- a/src/rust/lqos_node_manager/src/tracker/mod.rs
+++ b/src/rust/lqos_node_manager/src/tracker/mod.rs
@@ -73,7 +73,7 @@ pub struct ThroughputPerSecond {
 pub async fn current_throughput(
   _auth: AuthGuard,
 ) -> NoCache<MsgPack<ThroughputPerSecond>> {
-  let result = THROUGHPUT_BUFFER.read().await.current();
+  let result = THROUGHPUT_BUFFER.current();
   NoCache::new(MsgPack(result))
 }
 
@@ -81,7 +81,7 @@ pub async fn current_throughput(
 pub async fn throughput_ring_buffer(
   _auth: AuthGuard,
 ) -> NoCache<MsgPack<(usize, Vec<ThroughputPerSecond>)>> {
-  let result = THROUGHPUT_BUFFER.read().await.copy();
+  let result = THROUGHPUT_BUFFER.copy();
   NoCache::new(MsgPack(result))
 }
 

--- a/src/rust/lqos_node_manager/static/lqos.js
+++ b/src/rust/lqos_node_manager/static/lqos.js
@@ -359,7 +359,14 @@ class MultiRingBuffer {
             {x: x, y:this.data['shaped'].sortedY[1], name: 'Shaped Upload', type: 'scatter', fill: 'tozeroy', marker: {color: 'rgb(124,252,0)'}},
         ];
         if (this.plotted == null) {
-            Plotly.newPlot(graph, graphData, { margin: { l:0,r:0,b:0,t:0,pad:4 }, yaxis: { automargin: true, title: "Traffic (bits)" }, xaxis: {automargin: true, title: "Time since now (seconds)"} }, { responsive: true });
+            Plotly.newPlot(
+                graph, 
+                graphData, 
+                { 
+                    margin: { l:0,r:0,b:0,t:0,pad:4 }, 
+                    yaxis: { automargin: true, title: "Traffic (bits)", exponentformat: "SI" }, 
+                    xaxis: {automargin: true, title: "Time since now (seconds)"} 
+                }, { responsive: true });
             this.plotted = true;
         } else {
             Plotly.redraw(graph, graphData);

--- a/src/rust/lqos_sys/src/bpf/common/lpm.h
+++ b/src/rust/lqos_sys/src/bpf/common/lpm.h
@@ -89,8 +89,7 @@ static __always_inline struct ip_hash_info * setup_lookup_key_and_tc_cpu(
 {
     struct ip_hash_info * ip_info;
 
-    lookup_key->prefixlen = 128;
-    lookup_key->address = (direction == 1) ? dissector->dst_ip : 
+    lookup_key->address = (direction == 1) ? dissector->dst_ip :
         dissector->src_ip;
 
     #ifdef USE_HOTCACHE
@@ -105,6 +104,7 @@ static __always_inline struct ip_hash_info * setup_lookup_key_and_tc_cpu(
     }
     #endif
 
+    lookup_key->prefixlen = 128;
     ip_info = bpf_map_lookup_elem(
         &map_ip_to_cpu_and_tc, 
         lookup_key

--- a/src/rust/lqos_sys/src/bpf/common/lpm.h
+++ b/src/rust/lqos_sys/src/bpf/common/lpm.h
@@ -36,6 +36,7 @@ struct {
 	__uint(max_entries, HOT_CACHE_SIZE);
 	__type(key, struct in6_addr);
 	__type(value, struct ip_hash_info);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } ip_to_cpu_and_tc_hotcache SEC(".maps");
 #endif
 

--- a/src/rust/lqos_sys/src/bpf/common/maximums.h
+++ b/src/rust/lqos_sys/src/bpf/common/maximums.h
@@ -14,3 +14,6 @@
 
 // Maximum number of packet pairs to track per flow.
 #define MAX_PACKETS MAX_FLOWS
+
+// Hot Cache Size
+#define HOT_CACHE_SIZE 512

--- a/src/rust/lqos_sys/src/bpf/common/maximums.h
+++ b/src/rust/lqos_sys/src/bpf/common/maximums.h
@@ -16,4 +16,8 @@
 #define MAX_PACKETS MAX_FLOWS
 
 // Hot Cache Size
-#define HOT_CACHE_SIZE 512
+#define HOT_CACHE_SIZE 32768
+
+// Hot Cache Negative Hit Flag
+// If you have 4294967294 CPUs, I love you.
+#define NEGATIVE_HIT 4294967294

--- a/src/rust/remove_pinned_maps.sh
+++ b/src/rust/remove_pinned_maps.sh
@@ -14,3 +14,5 @@ rm -v /sys/fs/bpf/heimdall
 rm -v /sys/fs/bpf/heimdall_config
 rm -v /sys/fs/bpf/heimdall_watching
 rm -v /sys/fs/bpf/flowbee
+rm -v /sys/fs/bpf/ip_to_cpu_and_tc_hotcache
+


### PR DESCRIPTION
Small optimization for well-behaved setups that are correctly mapping their IP addresses (and a tiny slowdown for IPs that aren't). Does nothing at all for "on a stick" configurations:

* Adds a `TRACING` define to the XDP/TC kernels, allowing logging to `trace_pipe` of execution times. Not very accurate.
* Adds a `HOT_CACHE` define to `lpm.h`, setting this enables the hot cache.
* When an LPM check is required, the "hot cache" is checked first. If a hit occurs, it is returned immediately. if it doesn't occur, the IP/result is added to the hot cache.
* The Hot Cache is an LRU type, so it will expire old entries - keeping the "hot" ones over time.
* Added cache invalidation; the hot cache is invalidated whenever the IP map is edited.

My limited testing indicated a decent speed-up per-packet, although I don't trust the nanosecond measurements being emitted from the kernel - I think the clock doesn't update often enough.