### PR TITLE
Change the window title for the node manager to include a specified name from the config

### DIFF
--- a/src/rust/lqos_node_manager/src/config_control.rs
+++ b/src/rust/lqos_node_manager/src/config_control.rs
@@ -6,6 +6,15 @@ use rocket::{fs::NamedFile, serde::{json::Json, Serialize, Deserialize}};
 use rocket::serde::json::Value;
 use crate::tracker::SHAPED_DEVICES;
 
+#[get("/api/node_name")]
+pub async fn get_node_name() -> Json<String> {
+  if let Ok(config) = lqos_config::load_config() {
+    Json(config.node_name)
+  } else {
+    Json("No Name Provided".to_string())  
+  }
+}
+
 // Note that NoCache can be replaced with a cache option
 // once the design work is complete.
 #[get("/config")]

--- a/src/rust/lqos_node_manager/src/main.rs
+++ b/src/rust/lqos_node_manager/src/main.rs
@@ -89,6 +89,7 @@ fn rocket() -> _ {
         config_control::update_network_and_devices,
         config_control::update_lqos_tuning,
         config_control::update_lqosd_config,
+        config_control::get_node_name,
         auth_guard::create_first_user,
         auth_guard::login,
         auth_guard::admin_check,

--- a/src/rust/lqos_node_manager/static/circuit_queue.html
+++ b/src/rust/lqos_node_manager/static/circuit_queue.html
@@ -949,6 +949,7 @@
         }
 
         function start() {
+            setTitle();
             wireUpTabEvents();
             $("#btnPause").on('click', () => {
                 paused = !paused;

--- a/src/rust/lqos_node_manager/static/config.html
+++ b/src/rust/lqos_node_manager/static/config.html
@@ -1007,6 +1007,7 @@
         }
 
         function start() {
+            setTitle();
             display();
             colorReloadButton();
             updateHostCounts();

--- a/src/rust/lqos_node_manager/static/lqos.js
+++ b/src/rust/lqos_node_manager/static/lqos.js
@@ -497,3 +497,10 @@ function ipToHostname(ip) {
     })
     return ip;
 }
+
+function setTitle() {
+    $.get("/api/node_name", (name) => {
+        // Set the window title
+        document.title = name + " - LibreQoS Node Manager";
+    })
+}

--- a/src/rust/lqos_node_manager/static/main.html
+++ b/src/rust/lqos_node_manager/static/main.html
@@ -558,6 +558,7 @@
         }
 
         function start() {
+            setTitle();
             if (isRedacted()) {
                 //console.log("Redacting");
                 //css_getclass(".redact").style.filter = "blur(4px)";

--- a/src/rust/lqos_node_manager/static/shaped.html
+++ b/src/rust/lqos_node_manager/static/shaped.html
@@ -135,6 +135,7 @@
         }
 
         function start() {
+            setTitle();
             colorReloadButton();
             updateHostCounts();
             $.get("/api/shaped_devices_count", (count) => {

--- a/src/rust/lqos_node_manager/static/tree.html
+++ b/src/rust/lqos_node_manager/static/tree.html
@@ -270,6 +270,7 @@
             }
 
             function start() {
+                setTitle();
                 for (let i = 0; i < 20; ++i) rtt_histo.push(0);
                 colorReloadButton();
                 updateHostCounts();


### PR DESCRIPTION
Read the config via an API call and set the window title in Node Manager to include the node name. Requested by Trendall a while back.