### PR TITLE
Change download location for geo.bin

### DIFF
--- a/src/rust/lqosd/src/throughput_tracker/flow_data/flow_analysis/asn.rs
+++ b/src/rust/lqosd/src/throughput_tracker/flow_data/flow_analysis/asn.rs
@@ -46,7 +46,7 @@ impl GeoTable {
     fn download() -> anyhow::Result<()> {
         log::info!("Downloading ASN-IP Table");
         let file_path = Self::file_path();
-        let url = "https://bfnightly.bracketproductions.com/geo.bin";
+        let url = "https://stats.libreqos.io/geo.bin";
         let response = reqwest::blocking::get(url)?;
         let content = response.bytes()?;
         let bytes = &content[0..];


### PR DESCRIPTION
FIXES #489 
Change download location of `geo.bin` from my website to `stats.libreqos.io`.