### PR TITLE
Post integration hooks for scheduler.conf

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -13,6 +13,7 @@ if automatic_import_sonar():
 	from integrationSonar import importFromSonar
 from apscheduler.schedulers.background import BlockingScheduler
 from apscheduler.executors.pool import ThreadPoolExecutor
+import os.path
 
 ads = BlockingScheduler(executors={'default': ThreadPoolExecutor(1)})
 
@@ -39,6 +40,12 @@ def importFromCRM():
 			importFromSonar()
 		except:
 			print("Failed to import from Sonar")
+
+	# Post-CRM Hooks
+	path = get_libreqos_directory() + "/bin/post_integration_hook.sh"
+	binPath = get_libreqos_directory() + "/bin"
+	if os.path.isfile(path):
+        	subprocess.Popen(path, cwd=binPath)
 
 def graphHandler():
 	try:


### PR DESCRIPTION
Scheduler.py now checks for the existence of a `bin/post_integration_hook.sh` script. If it exists, it is executed immediately after CRM updating and before LibreQoS is refreshed.

This gives an opportuntity to start adding additional chains of calls to work with your shaped devices and network.json after CRM retrieval, and before pushing to live.