### PR TITLE
build_rust.sh improvements for ubuntu 24.04 LTS

### DIFF
--- a/src/build_rust.sh
+++ b/src/build_rust.sh
@@ -36,6 +36,18 @@ else
     echo "LLVM/clang found."
 fi
 
+if ! rustup -V &> /dev/null
+then
+    echo "rustup is not installed."
+    echo "Visit https://rustup.rs and install Rust from there"
+    echo "Usually, you can copy the following and follow the on-screen instructions."
+    echo "Please don't install Rust as root."
+    echo "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+    exit 1
+else
+    echo "rustup found."
+fi
+
 # To enable heavy debug mode (slow)
 #BUILD_FLAGS=""
 #TARGET=debug

--- a/src/build_rust.sh
+++ b/src/build_rust.sh
@@ -31,7 +31,7 @@ if ! clang -v &> /dev/null
 then
     echo "LLVM/clang is not installed."
     echo "Let's try to install it"
-    sudo apt install llvm libelf-dev gcc gcc-multilib libbpf-dev
+    sudo apt install llvm libelf-dev gcc gcc-multilib libbpf-dev libssl-dev
 else
     echo "LLVM/clang found."
 fi

--- a/src/build_rust.sh
+++ b/src/build_rust.sh
@@ -9,42 +9,7 @@
 # Don't forget to setup `/etc/lqos.conf`
 
 # Check Pre-Requisites
-if ! bpftool help &> /dev/null
-then
-    echo "bpftool is not installed."
-    echo "Let's try to install it"
-    sudo apt install linux-tools-common linux-tools-`uname -r`
-else
-    echo "bpftool found."
-fi
-
-if ! make -v &> /dev/null
-then
-    echo "make is not installed."
-    echo "Let's try to install it"
-    sudo apt install make
-else
-    echo "make found."
-fi
-
-
-if ! pkg-config --help &> /dev/null
-then
-    echo "pkg-config is not installed."
-    echo "Let's try to install it"
-    sudo apt install pkg-config
-else
-    echo "pkg-config found."
-fi
-
-if ! clang -v &> /dev/null
-then
-    echo "LLVM/clang is not installed."
-    echo "Let's try to install it"
-    sudo apt install llvm libelf-dev gcc gcc-multilib libbpf-dev libssl-dev
-else
-    echo "LLVM/clang found."
-fi
+sudo apt install python3-pip clang gcc gcc-multilib llvm libelf-dev git nano graphviz curl screen llvm pkg-config linux-tools-common linux-tools-`uname -r` libbpf-dev libssl-dev
 
 if ! rustup -V &> /dev/null
 then

--- a/src/build_rust.sh
+++ b/src/build_rust.sh
@@ -13,7 +13,7 @@ if ! bpftool help &> /dev/null
 then
     echo "bpftool is not installed."
     echo "Let's try to install it"
-    sudo apt-get install linux-tools-common linux-tools-`uname -r`
+    sudo apt install linux-tools-common linux-tools-`uname -r`
 else
     echo "bpftool found."
 fi
@@ -22,7 +22,7 @@ if ! pkg-config --help &> /dev/null
 then
     echo "pkg-config is not installed."
     echo "Let's try to install it"
-    sudo apt-get install pkg-config
+    sudo apt install pkg-config
 else
     echo "pkg-config found."
 fi
@@ -31,7 +31,7 @@ if ! clang -v &> /dev/null
 then
     echo "LLVM/clang is not installed."
     echo "Let's try to install it"
-    sudo apt-get install llvm libelf-dev gcc gcc-multilib libbpf-dev
+    sudo apt install llvm libelf-dev gcc gcc-multilib libbpf-dev
 else
     echo "LLVM/clang found."
 fi

--- a/src/build_rust.sh
+++ b/src/build_rust.sh
@@ -18,6 +18,16 @@ else
     echo "bpftool found."
 fi
 
+if ! make -v &> /dev/null
+then
+    echo "make is not installed."
+    echo "Let's try to install it"
+    sudo apt install make
+else
+    echo "make found."
+fi
+
+
 if ! pkg-config --help &> /dev/null
 then
     echo "pkg-config is not installed."


### PR DESCRIPTION
Purpose of this change:

```
Checking that Rust is uptodate
./build_rust.sh: line 51: rustup: command not found
Please wait while the system is compiled. Service will not be interrupted during this stage.
./build_rust.sh: line 62: cargo: command not found
Cargo build failed. Exiting with code 1.
```
(full log at http://kłopotek.pl/libreqos-beta.txt)