### PR TITLE
fix: removed doubled check "is lqosd running"

### DIFF
--- a/src/LibreQoS.py
+++ b/src/LibreQoS.py
@@ -1016,15 +1016,6 @@ def refreshShapers():
 		print("refreshShapers completed on " + datetime.now().strftime("%d/%m/%Y %H:%M:%S"))
 
 def refreshShapersUpdateOnly():
-	
-	# Check that the host lqosd is running
-	if is_lqosd_alive():
-		print("lqosd is running")
-	else:
-		print("ERROR: lqosd is not running. Aborting")
-		os._exit(-1)
-	
-	
 	# Starting
 	print("refreshShapers starting at " + datetime.now().strftime("%d/%m/%Y %H:%M:%S"))
 	


### PR DESCRIPTION
When running `./LibreQoS.py --update-only` there is a double check:

```
root@libreqos-beta:/opt/libreqos/src# ./LibreQoS.py --updateonly
Running Python Version 3.12.3 (main, Apr 10 2024, 05:33:47) [GCC 13.2.0]
lqosd is running
Configuration from /etc/lqos.conf is usable
lqosd is running
refreshShapers starting at 09/07/2024 09:12:18
Rust validated ShapedDevices.csv
ShapedDevices.csv passed validation
network.json passed validation
Observed no changes to ShapedDevices.csv or network.json. Leaving queues as is.
refreshShapersUpdateOnly completed on 09/07/2024 09:12:18
```

Please merge of if this is somehow intentional please move messages into function and leave `is_lqosd_alive()` only.