### PR TITLE
Quantum fixing

### DIFF
--- a/src/LibreQoS.py
+++ b/src/LibreQoS.py
@@ -839,6 +839,11 @@ def refreshShapers():
 				# If we aren't using cake, just return the sqm string
 				if not sqm.startswith("cake") or "rtt" in sqm:
 					return sqm()
+
+				# The rate is in Mbps, let's ask Cake to also handle the ceiling
+				# to help it auto-tune
+				sqm = sqm + " bandwidth " + str(rate) + "Mbit"
+
 				# If we are using cake, we need to fixup the rate
 				# Based on: 1 MTU is 1500 bytes, or 12,000 bits.
 				# At 1 Mbps, (1,000 bits per ms) transmitting an MTU takes 12ms. Add 3ms for overhead, and we get 15ms.

--- a/src/LibreQoS.py
+++ b/src/LibreQoS.py
@@ -840,10 +840,6 @@ def refreshShapers():
 				if not sqm.startswith("cake") or "rtt" in sqm:
 					return sqm()
 
-				# The rate is in Mbps, let's ask Cake to also handle the ceiling
-				# to help it auto-tune
-				sqm = sqm + " bandwidth " + str(rate) + "Mbit"
-
 				# If we are using cake, we need to fixup the rate
 				# Based on: 1 MTU is 1500 bytes, or 12,000 bits.
 				# At 1 Mbps, (1,000 bits per ms) transmitting an MTU takes 12ms. Add 3ms for overhead, and we get 15ms.

--- a/src/LibreQoS.py
+++ b/src/LibreQoS.py
@@ -35,7 +35,7 @@ def quantum(rateInMbps):
 	rateInBytesPerSecond = rateInMbps * 125000
 	quantum = int(rateInBytesPerSecond / R2Q)
 	quantrumString = " quantum " + str(quantum)
-	print("Calculated quantum for " + str(rateInMbps) + " Mbps: " + str(quantum))
+	#print("Calculated quantum for " + str(rateInMbps) + " Mbps: " + str(quantum))
 	return quantrumString
 	#return " quantum 1522"
 


### PR DESCRIPTION
Removes all HTB `r2q` errors. It appears that `tc` isn't setting `r2q` to 10 when working with a multi-headed queue of HTB trees. This patch uses the HTB default `quantum = rate_bytes_per_second / r2q` and applies it directly. It cut my network reload time by a LARGE amount.

The PR also specifies Cake bandwidth explicitly rather than implying it from the parent HTB. Testing seems to indicate that doesn't do very much.