### PR TITLE
ISSUE #542 - detect if SSL is in use, and adjust the websocket URL to…

### DIFF
--- a/src/rust/lqosd/src/node_manager/js_build/src/pubsub/direct_channels.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/pubsub/direct_channels.js
@@ -1,8 +1,10 @@
+import {ws_proto} from './ws.js';
+
 export class DirectChannel {
     constructor(subObject, handler) {
         this.ws = null;
         this.handler = handler;
-        this.ws = new WebSocket('ws://' + window.location.host + '/websocket/private_ws');
+        this.ws = new WebSocket(ws_proto() + window.location.host + '/websocket/private_ws');
         this.ws.onopen = () => {
             this.ws.send(JSON.stringify(subObject));
         }

--- a/src/rust/lqosd/src/node_manager/js_build/src/pubsub/ws.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/pubsub/ws.js
@@ -1,12 +1,20 @@
 // Setup any WS feeds for this page
 let ws = null;
 
+export function ws_proto() {
+    if (window.location.protocl === 'https') {
+        return "wss://";
+    } else {
+        return "ws://";
+    }
+}
+
 export function subscribeWS(channels, handler) {
     if (ws) {
         ws.close();
     }
 
-    ws = new WebSocket('ws://' + window.location.host + '/websocket/ws');
+    ws = new WebSocket(ws_proto() + window.location.host + '/websocket/ws');
     ws.onopen = () => {
         for (let i=0; i<channels.length; i++) {
             ws.send("{ \"channel\" : \"" + channels[i] + "\"}");


### PR DESCRIPTION
… match (either `wss://` or `ws://` for non-TLS).

The URLs to forward are:

* /websocket/ws (the main "ticker")
* /websocket/private_ws (for per-instance data feeds) - there's nothing actually "private" about it, it's "session local".

ISSUE #542 

(Not properly tested until I'm back home. Would be a good candidate for a little documentation, too. Don't merge yet!)