### PR TITLE
Remove sphinx from production build requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,4 @@ waitress
 setuptools >= 65.5.1
 apscheduler
 deepdiff
-sphinx
-sphinx_rtd_theme
 myst-parser


### PR DESCRIPTION
This PR simply removes the Sphinx dependencies from the package/production requirements.txt. requirements_dev.txt has sphinx specified, so it is unnecessary in the main file. 