### PR TITLE
Make geotable only load once.

### DIFF
--- a/src/rust/lqosd/src/throughput_tracker/flow_data/flow_analysis/asn.rs
+++ b/src/rust/lqosd/src/throughput_tracker/flow_data/flow_analysis/asn.rs
@@ -62,7 +62,7 @@ impl GeoTable {
     }
 
     fn download() -> anyhow::Result<()> {
-        debug!("Downloading ASN-IP Table");
+        tracing::warn!("Downloading ASN-IP Table");
         let file_path = Self::file_path();
         let url = "https://stats.libreqos.io/geo2.bin";
         let response = reqwest::blocking::get(url)?;


### PR DESCRIPTION
Corrects an issue that was causing high CPU and RAM usage after a few days.