### PR TITLE
Systemd dependency fixes

### DIFF
--- a/src/bin/lqosd.service.example
+++ b/src/bin/lqosd.service.example
@@ -1,5 +1,6 @@
 [Unit]
-After=network.service
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 WorkingDirectory=/opt/libreqos/src/bin


### PR DESCRIPTION
Potential fix for segfault of lqosd. I believe lqosd segfaults because it starts just after network.service initiates (before all interfaces are up). With this change, lqosd will only start after network-online.target is reached, where network interfaces are actually up.