### PR TITLE
Reset options on libqos_python to no longer depend upon a specific `l…

### DIFF
--- a/src/rust/lqos_python/Cargo.toml
+++ b/src/rust/lqos_python/Cargo.toml
@@ -9,7 +9,7 @@ name = "lqos_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = {  workspace = true }
+pyo3 = {  workspace = true, features = ["extension-module"] }
 lqos_bus = { path = "../lqos_bus" }
 lqos_utils = { path = "../lqos_utils" }
 lqos_config = { path = "../lqos_config" }


### PR DESCRIPTION
Adjust `lqos_python` to no longer require a direct link to `libpython`, using the `extension-module` feature.

LDD went from:

```
        linux-vdso.so.1 (0x00007fffbcef0000)
        libpython3.12.so.1.0 => /lib/x86_64-linux-gnu/libpython3.12.so.1.0 (0x00007dfd4d200000)
        libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007dfd4e956000)
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007dfd4cc00000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007dfd4e928000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007dfd4db17000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007dfd4c800000)
        /lib64/ld-linux-x86-64.so.2 (0x00007dfd4ea23000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007dfd4e90a000)
        libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007dfd4e8df000)
```

Down to just:

```
        linux-vdso.so.1 (0x00007fffdd56e000)
        libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x000071f3b1454000)
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x000071f3b0200000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x000071f3b07d2000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000071f3b0117000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000071f3afe00000)
        /lib64/ld-linux-x86-64.so.2 (0x000071f3b1521000)
```