### PR TITLE
Set bandwidth minimums to 0M for CRM/NMS integrations

### DIFF
--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -419,8 +419,8 @@ class NetworkGraph:
 							device["mac"],
 							device["ipv4"],
 							device["ipv6"],
-							int(float(circuit["download"]) * committed_bandwidth_multiplier()),
-							int(float(circuit["upload"]) * committed_bandwidth_multiplier()),
+							int(0),
+							int(0),
 							int(float(circuit["download"]) * bandwidth_overhead_factor()),
 							int(float(circuit["upload"]) * bandwidth_overhead_factor()),
 							""

--- a/src/rust/uisp_integration/src/strategies/flat.rs
+++ b/src/rust/uisp_integration/src/strategies/flat.rs
@@ -84,11 +84,9 @@ pub async fn build_flat_network(
                         config.queues.generated_pn_download_mbps,
                         config.queues.generated_pn_upload_mbps,
                     );
-                    let download_min = (download_max as f32
-                        * config.uisp_integration.commit_bandwidth_multiplier)
+                    let download_min = 0
                         as u64;
-                    let upload_min = (upload_max as f32
-                        * config.uisp_integration.commit_bandwidth_multiplier)
+                    let upload_min = 0
                         as u64;
                     for device in devices.iter() {
                         let dev = UispDevice::from_uisp(device, &config, &ip_ranges, &ipv4_to_v6);
@@ -103,10 +101,10 @@ pub async fn build_flat_network(
                                 mac: device.identification.mac.clone().unwrap_or("".to_string()),
                                 ipv4: dev.ipv4_list(),
                                 ipv6: dev.ipv6_list(),
-                                download_min: u64::max(2, download_min),
-                                download_max: u64::max(3, download_max as u64),
-                                upload_min: u64::max(2, upload_min),
-                                upload_max: u64::max(3, upload_max as u64),
+                                download_min: u64::max(0, download_min),
+                                download_max: u64::max(2, download_max as u64),
+                                upload_min: u64::max(0, upload_min),
+                                upload_max: u64::max(2, upload_max as u64),
                                 comment: "".to_string(),
                             };
                             shaped_devices.push(sd);

--- a/src/rust/uisp_integration/src/strategies/full/shaped_devices_writer.rs
+++ b/src/rust/uisp_integration/src/strategies/full/shaped_devices_writer.rs
@@ -91,11 +91,9 @@ fn traverse(
                     let upload_max = (sites[idx].max_up_mbps as f32
                         * config.uisp_integration.bandwidth_overhead_factor)
                         as u64;
-                    let download_min = (download_max as f32
-                        * config.uisp_integration.commit_bandwidth_multiplier)
+                    let download_min = 0
                         as u64;
-                    let upload_min = (upload_max as f32
-                        * config.uisp_integration.commit_bandwidth_multiplier)
+                    let upload_min = 0
                         as u64;
                     let sd = ShapedDevice {
                         circuit_id: sites[idx].id.clone(),
@@ -106,10 +104,10 @@ fn traverse(
                         mac: device.mac.clone(),
                         ipv4: device.ipv4_list(),
                         ipv6: device.ipv6_list(),
-                        download_min: u64::max(2, download_min),
-                        download_max: u64::max(3, download_max),
-                        upload_min: u64::max(2, upload_min),
-                        upload_max: u64::max(3, upload_max),
+                        download_min: u64::max(0, download_min),
+                        download_max: u64::max(2, download_max),
+                        upload_min: u64::max(0, upload_min),
+                        upload_max: u64::max(2, upload_max),
                         comment: "".to_string(),
                     };
                     shaped_devices.push(sd);


### PR DESCRIPTION
By default, the LibreQoS integrations set the minimum rates of Circuits to match their maximum rates. The problem with this is that that guarantees HTB oversubscription - leading to Nodes for APs and Sites going over their limits regularly. To fix this, this PR sets all circuits except infrastructure to a minimum of 0 Mbps (which is converted to 100kbps inside LibreQoS.py). That way, it becomes extremely unlikely to oversubscribe the HTB minimums.