### PR TITLE
Improvements to login form and search

### DIFF
--- a/src/rust/lqosd/src/node_manager/js_build/src/login.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/login.js
@@ -28,3 +28,11 @@ $("#btnLogin").on('click', () => {
         }
     })
 });
+
+// Add keypress handler for Enter key
+$('#username, #password').on('keypress', function(e) {
+    if (e.which === 13) { // 13 is Enter key code
+        e.preventDefault();
+        $('#btnLogin').click();
+    }
+});

--- a/src/rust/lqosd/src/node_manager/js_build/src/login.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/login.js
@@ -20,19 +20,27 @@ $("#btnLogin").on('click', () => {
         url: "/doLogin",
         data: JSON.stringify(login),
         contentType: 'application/json',
+        beforeSend: () => {
+            $("#loginError").removeClass("show").addClass("d-none");
+        },
         success: () => {
             window.location.href = "/index.html";
         },
         error: () => {
-            alert("Login Incorrect");
+            $("#loginError").removeClass("d-none").addClass("show");
         }
     })
 });
 
 // Add keypress handler for Enter key
 $('#username, #password').on('keypress', function(e) {
-    if (e.which === 13) { // 13 is Enter key code
+    if (e.which === 13) {
         e.preventDefault();
         $('#btnLogin').click();
     }
+});
+
+// Hide error when typing
+$('#username, #password').on('input', function() {
+    $("#loginError").fadeOut();
 });

--- a/src/rust/lqosd/src/node_manager/js_build/src/template.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/template.js
@@ -76,6 +76,14 @@ function setupSearch() {
         const search = $("#txtSearch").val();
         doSearch(search);
     });
+    
+    // Add this new key handler for '/' to focus search
+    $(document).on('keydown', (e) => {
+        if (e.key === '/' && !$(e.target).is('input, textarea, select')) {
+            e.preventDefault();
+            $('#txtSearch').focus();
+        }
+    });
 }
 
 function setupReload() {

--- a/src/rust/lqosd/src/node_manager/static2/login.html
+++ b/src/rust/lqosd/src/node_manager/static2/login.html
@@ -40,6 +40,11 @@
     </div>
 </div>
 
+<div id="loginError" class="alert alert-danger d-none mt-3">
+    <i class="fas fa-exclamation-triangle me-2"></i>
+    Login failed. You can manage users via the <code>lqusers</code> CLI tool on the LibreQoS server.
+</div>
+
 <script src="login.js"></script>
 
 <footer class="justify-content-center">


### PR DESCRIPTION
On the login form:
* The ugly alert popup for a failed login is now a nicer looking Bootstrap styled div.
* You can press ENTER in the username or password boxes to fire the login.

On all templated pages:
* Pressing `/` brings the search box into focus, enabling the `/bert` syntax to immediately search for `bert`.