### PR TITLE
Fix: explicitly don't try to check remote stats permission if "gather…

### DIFF
--- a/src/rust/lqosd/src/lts2_sys/lts2_client/ingestor.rs
+++ b/src/rust/lqosd/src/lts2_sys/lts2_client/ingestor.rs
@@ -59,7 +59,9 @@ fn ticker_timer(message_queue: Arc<Mutex<MessageQueue>>) {
             }
             info!("Queue send took: {:?}s", start.elapsed().as_secs_f32());
         } else {
-            info!("Queue is empty or not permitted to send - nothing to do");
+            if !permitted {
+                message_queue_lock.clear();
+            }
         }
     }
 }

--- a/src/rust/lqosd/src/lts2_sys/lts2_client/ingestor/permission.rs
+++ b/src/rust/lqosd/src/lts2_sys/lts2_client/ingestor/permission.rs
@@ -35,6 +35,11 @@ pub(crate) fn check_submit_permission() {
 fn check_permission() {
     println!("Checking for permission to submit");
     let config = load_config().unwrap();
+    if config.long_term_stats.gather_stats == false {
+        info!("Long term stats are disabled. Not checking license.");
+        ALLOWED_TO_SUBMIT.store(false, Ordering::Relaxed);
+        return;
+    }
     let remote_host = {
         config.long_term_stats.lts_url.clone().unwrap_or("insight.libreqos.com".to_string())
     };


### PR DESCRIPTION
Should FIX #651 - the external checks won't happen if gather_stats is false.