### PR TITLE
FIXES #659 - Cache Busters!

### DIFF
--- a/src/rust/lqosd/src/node_manager/static2/all_tree_sankey.html
+++ b/src/rust/lqosd/src/node_manager/static2/all_tree_sankey.html
@@ -11,4 +11,4 @@
 <div class="row" style="height: 98%;">
     <div class="col-12" style="height: 100%;" id="sankey"></div>
 </div>
-<script src="all_tree_sankey.js"></script>
+<script src="all_tree_sankey.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/asn_explorer.html
+++ b/src/rust/lqosd/src/node_manager/static2/asn_explorer.html
@@ -14,4 +14,4 @@
     </div>
 </div>
 
-<script src="asn_explorer.js"></script>
+<script src="asn_explorer.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/circuit.html
+++ b/src/rust/lqosd/src/node_manager/static2/circuit.html
@@ -116,4 +116,4 @@
 
 
 
-<script src="circuit.js"></script>
+<script src="circuit.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_anon.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_anon.html
@@ -42,4 +42,4 @@
     </div>
 </div>
 
-<script src="config_anon.js"></script>
+<script src="config_anon.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_devices.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_devices.html
@@ -31,6 +31,6 @@
             <i class="fa fa-save"></i> Save Changes
         </button>
         <div id="shapedDeviceTable"></div>
-        <script src="config_devices.js"></script>
+        <script src="config_devices.js%CACHEBUSTERS%"></script>
     </div>
 </div>

--- a/src/rust/lqosd/src/node_manager/static2/config_flows.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_flows.html
@@ -77,4 +77,4 @@
         </form>
     </div>
 </div>
-<script src="config_flows.js"></script>
+<script src="config_flows.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_general.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_general.html
@@ -63,4 +63,4 @@
     </div>
 </div>
 
-<script src="config_general.js"></script>
+<script src="config_general.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_integration.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_integration.html
@@ -47,4 +47,4 @@
         </form>
     </div>
 </div>
-<script src="config_integration.js"></script>
+<script src="config_integration.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_interface.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_interface.html
@@ -99,7 +99,7 @@
     </div>
 </div>
 
-<script src="config_interface.js"></script>
+<script src="config_interface.js%CACHEBUSTERS%"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const bridgeMode = document.getElementById('bridgeMode');

--- a/src/rust/lqosd/src/node_manager/static2/config_iprange.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_iprange.html
@@ -87,4 +87,4 @@
     </div>
 </div>
 
-<script src="config_iprange.js"></script>
+<script src="config_iprange.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_lts.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_lts.html
@@ -66,4 +66,4 @@
     </div>
 </div>
 
-<script src="config_lts.js"></script>
+<script src="config_lts.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_network.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_network.html
@@ -34,4 +34,4 @@
     </div>
 </div>
 
-<script src="config_network.js"></script>
+<script src="config_network.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_powercode.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_powercode.html
@@ -48,4 +48,4 @@
     </div>
 </div>
 
-<script src="config_powercode.js"></script>
+<script src="config_powercode.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_queues.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_queues.html
@@ -94,4 +94,4 @@
     </div>
 </div>
 
-<script src="config_queues.js"></script>
+<script src="config_queues.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_sonar.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_sonar.html
@@ -72,4 +72,4 @@
     </div>
 </div>
 
-<script src="config_sonar.js"></script>
+<script src="config_sonar.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_spylnx.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_spylnx.html
@@ -53,4 +53,4 @@
         </form>
     </div>
 </div>
-<script src="config_spylnx.js"></script>
+<script src="config_spylnx.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_tuning.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_tuning.html
@@ -79,4 +79,4 @@
     </div>
 </div>
 
-<script src="config_tuning.js"></script>
+<script src="config_tuning.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_uisp.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_uisp.html
@@ -108,4 +108,4 @@
     </div>
 </div>
 
-<script src="config_uisp.js"></script>
+<script src="config_uisp.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_users.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_users.html
@@ -104,4 +104,4 @@
     </div>
 </div>
 
-<script src="config_users.js"></script>
+<script src="config_users.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/config_wispgate.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_wispgate.html
@@ -49,4 +49,4 @@
     </div>
 </div>
 
-<script src="config_wispgate.js"></script>
+<script src="config_wispgate.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/configuration.html
+++ b/src/rust/lqosd/src/node_manager/static2/configuration.html
@@ -610,4 +610,4 @@
     </div>
 </div>
 
-<script src="configuration.js"></script>
+<script src="configuration.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/flow_map.html
+++ b/src/rust/lqosd/src/node_manager/static2/flow_map.html
@@ -3,4 +3,4 @@
 <div class="row" style="height: 100%;">
     <div class="col-12" style="height: 100%;" id="flowMap"></div>
 </div>
-<script src="flow_map.js"></script>
+<script src="flow_map.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/help.html
+++ b/src/rust/lqosd/src/node_manager/static2/help.html
@@ -180,4 +180,4 @@
     </div>
 </div>
 
-<script src="help.js"></script>
+<script src="help.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/index.html
+++ b/src/rust/lqosd/src/node_manager/static2/index.html
@@ -7,4 +7,4 @@
 <div id="toastHolder" class="toast-container position-fixed top-0 end-0 p-3" style="display: flex; flex-direction: column;">
 </div>
 
-<script src="index.js"></script>
+<script src="index.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/lts_trial.html
+++ b/src/rust/lqosd/src/node_manager/static2/lts_trial.html
@@ -74,4 +74,4 @@
     </div>
 </div>
 
-<script src="lts_trial.js"></script>
+<script src="lts_trial.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/shaped_devices.html
+++ b/src/rust/lqosd/src/node_manager/static2/shaped_devices.html
@@ -9,4 +9,4 @@
     </div>
 </div>
 
-<script src="shaped-devices.js"></script>
+<script src="shaped-devices.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/tree.html
+++ b/src/rust/lqosd/src/node_manager/static2/tree.html
@@ -34,4 +34,4 @@
     </div>
 </div>
 
-<script src="tree.js"></script>
+<script src="tree.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/static2/unknown_ips.html
+++ b/src/rust/lqosd/src/node_manager/static2/unknown_ips.html
@@ -11,4 +11,4 @@
     </div>
 </div>
 
-<script src="unknown-ips.js"></script>
+<script src="unknown-ips.js%CACHEBUSTERS%"></script>

--- a/src/rust/lqosd/src/node_manager/template.rs
+++ b/src/rust/lqosd/src/node_manager/template.rs
@@ -47,6 +47,8 @@ fn js_tf(b: bool) -> &'static str {
     if b { "true" } else { "false" }
 }
 
+static GIT_HASH: &str = env!("GIT_HASH");
+
 pub async fn apply_templates(
     jar: CookieJar,
     req: Request<axum::body::Body>,
@@ -133,6 +135,8 @@ pub async fn apply_templates(
             .replace("%%TITLE%%", &title)
             .replace("%%LTS_LINK%%", &trial_link)
             .replace("%%%LTS_SCRIPT%%%", &lts_script);
+        let byte_string = byte_string
+            .replace("%CACHEBUSTERS%", &format!("?gh={}", GIT_HASH));
         if let Some(length) = res_parts.headers.get_mut("content-length") {
             *length = HeaderValue::from(byte_string.len());
         }


### PR DESCRIPTION
Adds a ?gh=<current git hash> to all core JS loading URLs, to ensure that the current version is cached and future versions will be reloaded (and then cached).

Who you gonna call - Cache Busters!
![image](https://github.com/user-attachments/assets/9261b2d7-2411-4730-8171-e10634399ede)
