### PR TITLE
Issue 655 logins

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2170,7 +2170,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "lqos_bus",
  "lqos_config",
+ "tokio",
 ]
 
 [[package]]

--- a/src/rust/lqos_bus/src/bus/request.rs
+++ b/src/rust/lqos_bus/src/bus/request.rs
@@ -227,6 +227,9 @@ pub enum BusRequest {
 
     /// Finish a blackboard session
     BlackboardFinish,
+
+    /// Request that the user cache be invalidated
+    InvalidateUserCache,
 }
 
 /// Defines the parts of the blackboard

--- a/src/rust/lqosd/src/main.rs
+++ b/src/rust/lqosd/src/main.rs
@@ -409,6 +409,12 @@ fn handle_bus_requests(requests: &[BusRequest], responses: &mut Vec<BusResponse>
                 }
                 BusResponse::Ack
             }
+            BusRequest::InvalidateUserCache => {
+                std::thread::spawn(|| {
+                    node_manager::invalidate_user_cache_blocking();
+                });
+                BusResponse::Ack
+            }
         });
     }
 }

--- a/src/rust/lqosd/src/node_manager.rs
+++ b/src/rust/lqosd/src/node_manager.rs
@@ -9,3 +9,4 @@ mod ws;
 
 pub use run::spawn_webserver;
 pub use warnings::{WarningLevel, add_global_warning};
+pub use auth::invalidate_user_cache_blocking;

--- a/src/rust/lqosd/src/node_manager/auth.rs
+++ b/src/rust/lqosd/src/node_manager/auth.rs
@@ -12,13 +12,21 @@ use lqos_config::{UserRole, WebUsers};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+use tracing::info;
 
 const COOKIE_PATH: &str = "User-Token";
 
 static WEB_USERS: Lazy<Mutex<Option<WebUsers>>> = Lazy::new(|| Mutex::new(None));
 
 pub async fn invalidate_user_cache() {
+    info!("Invalidating user cache");
     let mut lock = WEB_USERS.lock().await;
+    *lock = None;
+}
+
+pub fn invalidate_user_cache_blocking() {
+    info!("Invalidating user cache");
+    let mut lock = WEB_USERS.blocking_lock();
     *lock = None;
 }
 

--- a/src/rust/lqosd/src/node_manager/auth.rs
+++ b/src/rust/lqosd/src/node_manager/auth.rs
@@ -12,7 +12,7 @@ use lqos_config::{UserRole, WebUsers};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use tracing::info;
+use tracing::{debug, info};
 
 const COOKIE_PATH: &str = "User-Token";
 
@@ -110,7 +110,7 @@ pub async fn auth_layer(
     Err(Html(BOUNCE))
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct LoginAttempt {
     pub username: String,
     pub password: String,
@@ -120,7 +120,19 @@ pub async fn try_login(
     jar: CookieJar,
     Json(login): Json<LoginAttempt>,
 ) -> Result<(CookieJar, StatusCode), StatusCode> {
-    let users = WEB_USERS.lock().await;
+    debug!("Attempting login for {:?}", login);
+    let mut users = WEB_USERS.lock().await;
+
+    if users.is_none() {
+        debug!("No users file loaded - attempting to load");
+        // No lock - let's see if there's a file to use?
+        if WebUsers::does_users_file_exist().unwrap() {
+            // It exists - we load it
+            let new_users = WebUsers::load_or_create().unwrap();
+            *users = Some(new_users);
+        }
+    }
+
     if let Some(users) = &*users {
         return match users.login(&login.username, &login.password) {
             Ok(token) => Ok((jar.add(Cookie::new(COOKIE_PATH, token)), StatusCode::OK)),

--- a/src/rust/lqosd/src/node_manager/auth.rs
+++ b/src/rust/lqosd/src/node_manager/auth.rs
@@ -17,6 +17,11 @@ const COOKIE_PATH: &str = "User-Token";
 
 static WEB_USERS: Lazy<Mutex<Option<WebUsers>>> = Lazy::new(|| Mutex::new(None));
 
+pub async fn invalidate_user_cache() {
+    let mut lock = WEB_USERS.lock().await;
+    *lock = None;
+}
+
 pub async fn get_username(jar: &CookieJar) -> String {
     let lock = WEB_USERS.lock().await;
     if let Some(users) = &*lock {

--- a/src/rust/lqosd/src/node_manager/local_api/config.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/config.rs
@@ -1,4 +1,4 @@
-use crate::node_manager::auth::LoginResult;
+use crate::node_manager::auth::{invalidate_user_cache, LoginResult};
 use crate::shaped_devices_tracker::SHAPED_DEVICES;
 use axum::http::StatusCode;
 use axum::{Extension, Json};
@@ -152,6 +152,7 @@ pub async fn add_user(
     users
         .add_or_update_user(&data.username.trim(), &data.password, data.role.into())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    invalidate_user_cache().await;
     Ok(format!("User '{}' added", data.username))
 }
 
@@ -166,6 +167,7 @@ pub async fn update_user(
     users
         .add_or_update_user(&data.username, &data.password, data.role.into())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    invalidate_user_cache().await;
     Ok("User updated".to_string())
 }
 
@@ -185,5 +187,6 @@ pub async fn delete_user(
     users
         .remove_user(&data.username)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    invalidate_user_cache().await;
     Ok("User deleted".to_string())
 }

--- a/src/rust/lqusers/Cargo.toml
+++ b/src/rust/lqusers/Cargo.toml
@@ -8,3 +8,5 @@ license = "GPL-2.0-only"
 clap = { workspace = true }
 lqos_config = { path = "../lqos_config" }
 anyhow = { workspace = true }
+lqos_bus = { path = "../lqos_bus" }
+tokio = { workspace = true }

--- a/src/rust/lqusers/src/main.rs
+++ b/src/rust/lqusers/src/main.rs
@@ -35,7 +35,12 @@ enum Commands {
     List,
 }
 
-fn main() -> Result<()> {
+async fn invalidate_user_cache() {
+    let _ = lqos_bus::bus_request(vec![lqos_bus::BusRequest::InvalidateUserCache]).await;
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
     let cli = Args::parse();
     let mut users = WebUsers::load_or_create()?;
     match cli.command {
@@ -45,9 +50,11 @@ fn main() -> Result<()> {
             password,
         }) => {
             users.add_or_update_user(&username, &password, role)?;
+            invalidate_user_cache().await;
         }
         Some(Commands::Del { username }) => {
             users.remove_user(&username)?;
+            invalidate_user_cache().await;
         }
         Some(Commands::List) => {
             println!("All Users\n");
@@ -58,6 +65,5 @@ fn main() -> Result<()> {
             exit(0);
         }
     }
-
     Ok(())
 }


### PR DESCRIPTION
Cleans up the node manager login system.
* Provides a "cache invalidate" call on save/update of a user.
* Adds the cache invalidation to the bus.
* `lqusers` now invalidates the cache if `lqosd` is running (and doesn't error otherwise).
* Fixes the logic of when to load the users list.

FIXES #655 