### PR TITLE
Restart LibreQoS scheduler when Reload is clicked

### DIFF
--- a/src/rust/lqos_config/src/program_control.rs
+++ b/src/rust/lqos_config/src/program_control.rs
@@ -35,27 +35,27 @@ pub fn load_libreqos() -> Result<String, ProgramControlError> {
         return Err(ProgramControlError::PythonNotFound);
     }
 
-    let result = Command::new(PYTHON_PATH)
+    let reload_result = Command::new(PYTHON_PATH)
         .current_dir(working_directory()?)
         .arg("LibreQoS.py")
         .output()
         .map_err(|_| ProgramControlError::CommandFailed)?;
-    let stdout =
-        String::from_utf8(result.stdout).map_err(|_| ProgramControlError::StdInErrAccess)?;
-    let stderr =
-        String::from_utf8(result.stderr).map_err(|_| ProgramControlError::StdInErrAccess)?;
+    let reload_stdout =
+        String::from_utf8(reload_result.stdout).map_err(|_| ProgramControlError::StdInErrAccess)?;
+    let reload_stderr =
+        String::from_utf8(reload_result.stderr).map_err(|_| ProgramControlError::StdInErrAccess)?;
 
     // Also reload the scheduler service
-    let mut result_display = stdout + &stderr + "\n\nReloading Scheduler\n";
-    let result = Command::new("/bin/systemctl")
+    let mut result_display = reload_stdout + &reload_stderr + "\n\nReloading Scheduler\n";
+    let restart_result = Command::new("/bin/systemctl")
         .arg("restart")
         .arg("lqos_scheduler")
         .output()
         .map_err(|_| ProgramControlError::CommandFailed)?;
     let restart_stdout =
-        String::from_utf8(result.stdout).map_err(|_| ProgramControlError::StdInErrAccess)?;
+        String::from_utf8(restart_result.stdout).map_err(|_| ProgramControlError::StdInErrAccess)?;
     let restart_stderr =
-        String::from_utf8(result.stderr).map_err(|_| ProgramControlError::StdInErrAccess)?;
+        String::from_utf8(restart_result.stderr).map_err(|_| ProgramControlError::StdInErrAccess)?;
 
     result_display += &restart_stdout;
     result_display += &restart_stderr;

--- a/src/rust/lqos_config/src/program_control.rs
+++ b/src/rust/lqos_config/src/program_control.rs
@@ -44,7 +44,22 @@ pub fn load_libreqos() -> Result<String, ProgramControlError> {
         String::from_utf8(result.stdout).map_err(|_| ProgramControlError::StdInErrAccess)?;
     let stderr =
         String::from_utf8(result.stderr).map_err(|_| ProgramControlError::StdInErrAccess)?;
-    Ok(stdout + &stderr)
+
+    let mut result_display = stdout + &stderr + "\n\nReloading Scheduler\n";
+    let result = Command::new("/bin/systemctl")
+        .arg("restart")
+        .arg("lqos_scheduler")
+        .output()
+        .map_err(|_| ProgramControlError::CommandFailed)?;
+    let stdout =
+        String::from_utf8(result.stdout).map_err(|_| ProgramControlError::StdInErrAccess)?;
+    let stderr =
+        String::from_utf8(result.stderr).map_err(|_| ProgramControlError::StdInErrAccess)?;
+
+    result_display += &stdout;
+    result_display += &stderr;
+
+    Ok(result_display)
 }
 
 #[derive(Error, Debug)]

--- a/src/rust/lqos_config/src/program_control.rs
+++ b/src/rust/lqos_config/src/program_control.rs
@@ -45,19 +45,20 @@ pub fn load_libreqos() -> Result<String, ProgramControlError> {
     let stderr =
         String::from_utf8(result.stderr).map_err(|_| ProgramControlError::StdInErrAccess)?;
 
+    // Also reload the scheduler service
     let mut result_display = stdout + &stderr + "\n\nReloading Scheduler\n";
     let result = Command::new("/bin/systemctl")
         .arg("restart")
         .arg("lqos_scheduler")
         .output()
         .map_err(|_| ProgramControlError::CommandFailed)?;
-    let stdout =
+    let restart_stdout =
         String::from_utf8(result.stdout).map_err(|_| ProgramControlError::StdInErrAccess)?;
-    let stderr =
+    let restart_stderr =
         String::from_utf8(result.stderr).map_err(|_| ProgramControlError::StdInErrAccess)?;
 
-    result_display += &stdout;
-    result_display += &stderr;
+    result_display += &restart_stdout;
+    result_display += &restart_stderr;
 
     Ok(result_display)
 }


### PR DESCRIPTION
FIXES #669 

The LibreQoS Scheduler service will be restarted when "Reload LibreQoS" is clicked, and any messages from the restart appended to the output.