### PR TITLE
Integration common client bandwidth multiplier

### DIFF
--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -5,7 +5,7 @@ from typing import List, Any
 from liblqos_python import allowed_subnets, ignore_subnets, generated_pn_download_mbps, generated_pn_upload_mbps, \
 	circuit_name_use_address, upstream_bandwidth_capacity_download_mbps, upstream_bandwidth_capacity_upload_mbps, \
 	find_ipv6_using_mikrotik, exclude_sites, bandwidth_overhead_factor, committed_bandwidth_multiplier, \
-	exception_cpes, promote_to_root_list
+	exception_cpes, promote_to_root_list, client_bandwidth_multiplier
 import ipaddress
 import enum
 import os
@@ -403,7 +403,6 @@ class NetworkGraph:
 							circuit["devices"].append(device)
 					if len(circuit["devices"]) > 0:
 						circuits.append(circuit)
-
 			with open('ShapedDevices.csv', 'w', newline='') as csvfile:
 				wr = csv.writer(csvfile, quoting=csv.QUOTE_ALL)
 				wr.writerow(['Circuit ID', 'Circuit Name', 'Device ID', 'Device Name', 'Parent Node', 'MAC',
@@ -428,8 +427,8 @@ class NetworkGraph:
 							device["ipv6"],
 							int(1),
 							int(1),
-							int(float(circuit["download"]) * bandwidth_overhead_factor()),
-							int(float(circuit["upload"]) * bandwidth_overhead_factor()),
+							int(float(circuit["download"]) * client_bandwidth_multiplier()),
+							int(float(circuit["upload"]) * client_bandwidth_multiplier()),
 							""
 						]
 						wr.writerow(row)

--- a/src/rust/lqos_config/src/etc/v15/integration_common.rs
+++ b/src/rust/lqos_config/src/etc/v15/integration_common.rs
@@ -15,6 +15,9 @@ pub struct IntegrationConfig {
 
     /// Root node promotion
     pub promote_to_root: Option<Vec<String>>,
+
+    /// Client bandwidth multiplier
+    pub client_bandwidth_multiplier: Option<f32>,
 }
 
 impl Default for IntegrationConfig {
@@ -24,6 +27,7 @@ impl Default for IntegrationConfig {
             always_overwrite_network_json: false,
             queue_refresh_interval_mins: 30,
             promote_to_root: None,
+            client_bandwidth_multiplier: None,
         }
     }
 }

--- a/src/rust/lqos_python/src/lib.rs
+++ b/src/rust/lqos_python/src/lib.rs
@@ -99,6 +99,7 @@ fn liblqos_python(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(wispgate_api_token))?;
     m.add_wrapped(wrap_pyfunction!(wispgate_api_url))?;
     m.add_wrapped(wrap_pyfunction!(promote_to_root_list))?;
+    m.add_wrapped(wrap_pyfunction!(client_bandwidth_multiplier))?;
 
     Ok(())
 }
@@ -782,4 +783,10 @@ fn promote_to_root_list() -> PyResult<Vec<String>> {
         return Ok(vec![]);
     };
     Ok(promote_to_root.clone())
+}
+
+#[pyfunction]
+fn client_bandwidth_multiplier() -> PyResult<f32> {
+    let config = lqos_config::load_config().unwrap();
+    Ok(config.integration_common.client_bandwidth_multiplier.unwrap_or(1.0))
 }

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_integration.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_integration.js
@@ -16,6 +16,14 @@ function validateConfig() {
         alert("Please remove empty lines from Promote to Root Nodes");
         return false;
     }
+    
+    // Validate multiplier
+    const multiplier = parseFloat(document.getElementById("clientBandwidthMultiplier").value);
+    if (isNaN(multiplier) || multiplier <= 0) {
+        alert("Client Bandwidth Multiplier must be a number greater than 0");
+        return false;
+    }
+    
     return true;
 }
 
@@ -31,6 +39,10 @@ function updateConfig() {
                 .map(line => line.trim())
                 .filter(line => line.length > 0);
             return list.length > 0 ? list : null;
+        })(),
+        client_bandwidth_multiplier: (() => {
+            const value = parseFloat(document.getElementById("clientBandwidthMultiplier").value);
+            return value === 1.0 ? null : value; // Store as null for default to save space
         })()
     };
 }
@@ -54,6 +66,8 @@ loadConfig(() => {
         // Promote to root field
         const promoteRoot = integration.promote_to_root ? integration.promote_to_root.join('\n') : '';
         document.getElementById("promoteToRoot").value = promoteRoot;
+        document.getElementById("clientBandwidthMultiplier").value = 
+            (integration.client_bandwidth_multiplier ?? 1.0).toFixed(1);
 
         // Add save button click handler
         document.getElementById('saveButton').addEventListener('click', () => {

--- a/src/rust/lqosd/src/node_manager/static2/config_integration.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_integration.html
@@ -49,6 +49,12 @@
                 <div class="form-text">Enter one circuit ID per line to promote to root nodes</div>
             </div>
 
+            <div class="mb-3">
+                <label for="clientBandwidthMultiplier" class="form-label">Client Bandwidth Multiplier</label>
+                <input type="number" class="form-control" id="clientBandwidthMultiplier" step="0.1" min="0.1" value="1.0">
+                <div class="form-text">Multiplier applied to client bandwidth values (1.0 = 100%)</div>
+            </div>
+
             <button type="button" id="saveButton" class="btn btn-outline-primary">Save Changes</button>
         </form>
     </div>


### PR DESCRIPTION
For integrations using the common framework (Splynx, Powercode, Sonar) you can add some cushion above the plan rate using the new `client_bandwidth_multiplier` variable in the `[integration_common]` section of `/etc/lqos.conf`. By default, the value of `client_bandwidth_multiplier` is 1.00. A value of 1.2-1.3 is recommended to ensure sufficient cushion that client speed tests are always accurate.