### PR TITLE
Fix #699

### DIFF
--- a/src/LibreQoS.py
+++ b/src/LibreQoS.py
@@ -379,7 +379,7 @@ def loadSubscriberCircuits(shapedDevicesFile):
 					knownCircuitIDs.append(circuitID)
 					if ParentNode == "":
 						ParentNode = "none"
-					ParentNode = ParentNode.strip()
+					#ParentNode = ParentNode.strip()
 					deviceListForCircuit = []
 					thisDevice = 	{
 									  "deviceID": deviceID,
@@ -414,7 +414,7 @@ def loadSubscriberCircuits(shapedDevicesFile):
 					circuitName = deviceName
 				if ParentNode == "":
 					ParentNode = "none"
-				ParentNode = ParentNode.strip()
+				#ParentNode = ParentNode.strip()
 				deviceListForCircuit = []
 				thisDevice = 	{
 								  "deviceID": deviceID,


### PR DESCRIPTION
Stops LibreQoS.py from doing a strip() function on the parent node name, since that leads to the issue in #699.