### PR TITLE
Flip the colors on the shaped/unshaped pie chart.

### DIFF
--- a/src/rust/lqosd/src/node_manager/js_build/src/graphs/shaped_unshaped_pie.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/graphs/shaped_unshaped_pie.js
@@ -9,8 +9,8 @@ export class ShapedUnshapedPie extends DashboardGraph {
                     type: 'pie',
                     radius: '50%',
                     data: [
+                        { name: 'Unshaped', value: 0 },
                         { name: 'Shaped', value: 0 },
-                        { name: 'Unshaped', value: 0 }
                     ],
                 }
             ],
@@ -23,8 +23,8 @@ export class ShapedUnshapedPie extends DashboardGraph {
 
     update(shaped, unshaped) {
         this.chart.hideLoading();
-        this.option.series[0].data[0].value = shaped;
-        this.option.series[0].data[1].value = unshaped - shaped;
+        this.option.series[0].data[1].value = shaped;
+        this.option.series[0].data[0].value = unshaped - shaped;
         this.chart.setOption(this.option);
     }
 }


### PR DESCRIPTION
 Green is good, so it's shaped in dark mode. Red is not so good, so it's unshaped in light mode.