### PR TITLE
Feat: Add a /health route that returns 200/OK.

### DIFF
--- a/src/rust/lqosd/src/node_manager/run.rs
+++ b/src/rust/lqosd/src/node_manager/run.rs
@@ -8,6 +8,7 @@ use crate::node_manager::{
 use crate::system_stats::SystemStats;
 use anyhow::{Result, bail};
 use axum::Router;
+use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum::routing::{get, post};
 use lqos_bus::BusRequest;
@@ -72,6 +73,6 @@ async fn redirect_to_index() -> Redirect {
 }
 
 /// Provides a simple OK status
-async fn health_check() -> &'static str {
-    "OK"
+async fn health_check() -> (StatusCode, &'static str) {
+    (StatusCode::OK, "OK")
 }

--- a/src/rust/lqosd/src/node_manager/run.rs
+++ b/src/rust/lqosd/src/node_manager/run.rs
@@ -50,6 +50,7 @@ pub async fn spawn_webserver(
         .route("/", get(redirect_to_index))
         .route("/doLogin", post(auth::try_login))
         .route("/firstLogin", post(auth::first_user))
+        .route("/health", get(health_check))
         .nest(
             "/websocket/",
             websocket_router(bus_tx.clone(), system_usage_tx.clone()),
@@ -68,4 +69,9 @@ pub async fn spawn_webserver(
 /// to the index.html page.
 async fn redirect_to_index() -> Redirect {
     Redirect::permanent("/index.html")
+}
+
+/// Provides a simple OK status
+async fn health_check() -> &'static str {
+    "OK"
 }


### PR DESCRIPTION
Adds a route to `/health` that returns `OK` (220 plus plain text).

<img width="446" alt="image" src="https://github.com/user-attachments/assets/455db736-3672-4cfb-a927-589b1ff8b61c" />

FIXES #720 