### PR TITLE
eBPF RTT monitoring fixes

### DIFF
--- a/src/rust/lqos_sys/src/bpf/common/flows.h
+++ b/src/rust/lqos_sys/src/bpf/common/flows.h
@@ -14,6 +14,7 @@
 #define RTT_RING_SIZE 4
 //#define TIMESTAMP_INTERVAL_NANOS 10000000
 #define TIMEOUT_TSVAL_NS (10 * SECOND_IN_NANOS)
+#define MIN_RTT_SAMPLE_INTERVAL (SECOND_IN_NANOS / 10)
 
 // Some helpers to make understanding direction easier
 // for readability.
@@ -81,6 +82,8 @@ struct flow_data_t {
     __u32 tsecr[2];
     // When did the timestamp change?
     struct tsval_record_buffer_t tsval_tstamps[2];
+    // Last time we pushed an RTT sample
+    __u64 last_rtt[2];
     // Has the connection ended?
     // 0 = Alive, 1 = FIN, 2 = RST
     __u8 end_status;
@@ -137,6 +140,7 @@ static __always_inline struct flow_data_t new_flow_data(
         .tsval = { 0, 0 },
         .tsecr = { 0, 0 },
         .tsval_tstamps = { { 0 }, { 0 } },
+        .last_rtt = { 0, 0 },
         .end_status = 0,
         .tos = 0,
         .ip_flags = 0,
@@ -396,11 +400,14 @@ static __always_inline void infer_tcp_rtt(
         if (match_at > 0) {
             __u64 elapsed = dissector->now - match_at;
 
-            struct flowbee_event event = { 0 };
-            event.key = *key;
-            event.round_trip_time = elapsed;
-            event.effective_direction = other_rate_index; // direction of the origial TCP segment we matched against
-            bpf_ringbuf_output(&flowbee_events, &event, sizeof(event), 0);
+            if (data->last_rtt[other_rate_index] + MIN_RTT_SAMPLE_INTERVAL < dissector->now) {
+                struct flowbee_event event = {0};
+                event.key = *key;
+                event.round_trip_time = elapsed;
+                event.effective_direction = other_rate_index; // direction of the origial TCP segment we matched against
+                bpf_ringbuf_output(&flowbee_events, &event, sizeof(event), 0);
+                data->last_rtt[other_rate_index] = dissector->now;
+            }
         }
     }
 

--- a/src/rust/lqos_sys/src/bpf/common/flows.h
+++ b/src/rust/lqos_sys/src/bpf/common/flows.h
@@ -251,6 +251,50 @@ static __always_inline void detect_retries(
     data->last_ack[rate_index] = ack_seq;
 }
 
+
+// Passively infer TCP RTT by matching ACKs to previous TCP segments using TCP
+// timestamps (TSval/TSecr).
+// Stores previous TSval value and checks if TSecr of current packet matches a
+// previously sent TSval in the reverse direction and calculate the RTT as
+// the time since the original TSval was sent. The approach is based on Kathleen
+// Nichols' pping (https://pollere.net/pping.html), but modified to store
+// TSvals as part of the flow state (the data argument).
+static __always_inline void infer_tcp_rtt(
+    struct dissector_t *dissector,
+    struct flow_key_t *key,
+    struct flow_data_t *data,
+    u_int8_t rate_index,
+    u_int8_t other_rate_index
+) {
+    if (dissector->tsval == 0)
+        return;
+
+    //bpf_debug("[FLOWS][%d] TSVAL: %u, TSECR: %u", direction, tsval, tsecr);
+    if (dissector->tsval != data->tsval[rate_index] && dissector->tsecr != data->tsecr[rate_index]) {
+
+        if (
+            dissector->tsecr == data->tsval[other_rate_index] &&
+            (data->rate_estimate_bps[rate_index] > 0 ||
+             data->rate_estimate_bps[other_rate_index] > 0 )
+        ) {
+            __u64 elapsed = dissector->now - data->ts_change_time[other_rate_index];
+            if (elapsed < TWO_SECONDS_IN_NANOS) {
+                struct flowbee_event event = { 0 };
+                event.key = *key;
+                event.round_trip_time = elapsed;
+                event.effective_direction = rate_index;
+                bpf_ringbuf_output(&flowbee_events, &event, sizeof(event), 0);
+            }
+        }
+
+        data->ts_change_time[rate_index] = dissector->now;
+        data->tsval[rate_index] = dissector->tsval;
+        data->tsecr[rate_index] = dissector->tsecr;
+    }
+
+    return;
+}
+
 // Handle Per-Flow TCP Analysis
 static __always_inline void process_tcp(
     struct dissector_t *dissector,
@@ -294,31 +338,8 @@ static __always_inline void process_tcp(
     // Sequence and Acknowledgement numbers
     detect_retries(dissector, rate_index, data);
 
-    // Timestamps to calculate RTT
-    if (dissector->tsval != 0) {
-        //bpf_debug("[FLOWS][%d] TSVAL: %u, TSECR: %u", direction, tsval, tsecr);
-        if (dissector->tsval != data->tsval[rate_index] && dissector->tsecr != data->tsecr[rate_index]) {
-
-            if (
-                dissector->tsecr == data->tsval[other_rate_index] &&
-                (data->rate_estimate_bps[rate_index] > 0 ||
-                data->rate_estimate_bps[other_rate_index] > 0 )
-            ) {
-                __u64 elapsed = dissector->now - data->ts_change_time[other_rate_index];
-                if (elapsed < TWO_SECONDS_IN_NANOS) {
-                    struct flowbee_event event = { 0 };
-                    event.key = key;
-                    event.round_trip_time = elapsed;
-                    event.effective_direction = rate_index;
-                    bpf_ringbuf_output(&flowbee_events, &event, sizeof(event), 0);
-                }
-            }
-
-            data->ts_change_time[rate_index] = dissector->now;
-            data->tsval[rate_index] = dissector->tsval;
-            data->tsecr[rate_index] = dissector->tsecr;
-        }
-    }
+    // Check TCP timestamps and attempt to calculate RTT
+    infer_tcp_rtt(dissector, &key, data, rate_index, other_rate_index);
 
     // Has the connection ended?
     if (BITCHECK(DIS_TCP_FIN)) {

--- a/src/rust/lqos_sys/src/bpf/common/flows.h
+++ b/src/rust/lqos_sys/src/bpf/common/flows.h
@@ -149,6 +149,14 @@ static __always_inline struct flow_key_t build_flow_key(
     };
 }
 
+// Checks if a < b considering u32 wraparound (logic from RFC 7323 Section 5.2)
+static __always_inline bool u32wrap_lt(
+    __u32 a,
+    __u32 b)
+{
+    return a != b && b - a < 1UL << 31;
+}
+
 // Update the flow data with the current packet's information.
 // * Update the timestamp of the last seen packet
 // * Update the bytes and packets sent
@@ -270,9 +278,27 @@ static __always_inline void infer_tcp_rtt(
         return;
 
     //bpf_debug("[FLOWS][%d] TSVAL: %u, TSECR: %u", direction, tsval, tsecr);
-    if (dissector->tsval != data->tsval[rate_index] && dissector->tsecr != data->tsecr[rate_index]) {
 
-        // Match check
+    // Update TSval in forward (rate_index) direction
+    if (
+        data->tsval[rate_index] == 0 || // No previous TSval
+        u32wrap_lt(data->tsval[rate_index], dissector->tsval) // New TSval
+    ) {
+        data->tsval[rate_index] = dissector->tsval;
+        data->ts_change_time[rate_index] = dissector->now;
+    }
+
+    if (dissector->tsecr == 0)
+        return;
+
+    // Update TSecr in forward direction + check match in reverse (other_rate_index) direction
+    if (
+        data->tsecr[rate_index] == 0 || // No previous TSecr
+        u32wrap_lt(data->tsecr[rate_index], dissector->tsecr) // New TSecr
+    ) {
+        data->tsecr[rate_index] = dissector->tsecr;
+
+        // Match TSecr against previous TSval in reverse direction
         if (dissector->tsecr == data->tsval[other_rate_index]) {
             __u64 elapsed = dissector->now - data->ts_change_time[other_rate_index];
             if (elapsed < TWO_SECONDS_IN_NANOS) {
@@ -283,10 +309,6 @@ static __always_inline void infer_tcp_rtt(
                 bpf_ringbuf_output(&flowbee_events, &event, sizeof(event), 0);
             }
         }
-
-        data->ts_change_time[rate_index] = dissector->now;
-        data->tsval[rate_index] = dissector->tsval;
-        data->tsecr[rate_index] = dissector->tsecr;
     }
 
     return;

--- a/src/rust/lqos_sys/src/bpf/common/flows.h
+++ b/src/rust/lqos_sys/src/bpf/common/flows.h
@@ -282,7 +282,7 @@ static __always_inline void infer_tcp_rtt(
                 struct flowbee_event event = { 0 };
                 event.key = *key;
                 event.round_trip_time = elapsed;
-                event.effective_direction = rate_index;
+                event.effective_direction = other_rate_index; // direction of the origial TCP segment we matched against
                 bpf_ringbuf_output(&flowbee_events, &event, sizeof(event), 0);
             }
         }

--- a/src/rust/lqos_sys/src/bpf/common/flows.h
+++ b/src/rust/lqos_sys/src/bpf/common/flows.h
@@ -278,6 +278,23 @@ static __always_inline void detect_retries(
     data->last_ack[rate_index] = ack_seq;
 }
 
+static __always_inline int get_tcp_segment_size(
+    struct dissector_t *dissector
+) {
+    struct tcphdr *tcph;
+    char *payload_start;
+
+    tcph = get_tcp_header(dissector);
+    if (!tcph || tcph + 1 > dissector->end)
+        return -1;
+
+    payload_start = (char *)tcph + tcph->doff * 4;
+    if (payload_start < (char *)(tcph + 1) || payload_start > dissector->end)
+        return -1;
+
+    return (char *)dissector->end - payload_start;
+}
+
 // Add a TSval <-> timestamp mapping to buf.
 // Will overwrite outdated (timed out) entries.
 // Will return 0 on success, or -1 if there was no free slot in buf.
@@ -357,7 +374,11 @@ static __always_inline void infer_tcp_rtt(
         u32wrap_lt(data->tsval[rate_index], dissector->tsval) // New TSval
     ) {
         data->tsval[rate_index] = dissector->tsval;
-        record_tsval(&data->tsval_tstamps[rate_index], dissector->now, dissector->tsval);
+
+        // Only attempt to track TSval if it's not a pure ACK
+        if (get_tcp_segment_size(dissector) > 0 || BITCHECK(DIS_TCP_SYN))
+            record_tsval(&data->tsval_tstamps[rate_index], dissector->now,
+                         dissector->tsval);
     }
 
     if (dissector->tsecr == 0)

--- a/src/rust/lqos_sys/src/bpf/common/flows.h
+++ b/src/rust/lqos_sys/src/bpf/common/flows.h
@@ -8,12 +8,13 @@
 #include "debug.h"
 
 
-#define SECOND_IN_NANOS 1000000000
+#define SECOND_IN_NANOS 1000000000ULL
 #define TWO_SECONDS_IN_NANOS 2000000000
 #define MS_IN_NANOS_T10 10000
 #define HALF_MBPS_IN_BYTES_PER_SECOND 62500
 #define RTT_RING_SIZE 4
 //#define TIMESTAMP_INTERVAL_NANOS 10000000
+#define TIMEOUT_TSVAL_NS (10 * SECOND_IN_NANOS)
 
 // Some helpers to make understanding direction easier
 // for readability.
@@ -21,6 +22,10 @@
 #define FROM_INTERNET 1
 #define TO_LOCAL 1
 #define FROM_LOCAL 2
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+#endif
 
 // Defines a TCP connection flow key
 struct flow_key_t {
@@ -32,6 +37,15 @@ struct flow_key_t {
     __u8 pad;
     __u8 pad1;
     __u8 pad2;
+};
+
+struct tsval_record_buffer_t {
+    // Times when TSvals were observed
+    // If an entry is 0 is means the spot is free
+    __u64 timestamps[2];
+    // The corresponding TSvals that were observed
+    // tsval[i] is only valid if timestamp[i] > 0
+    __u32 tsvals[2];
 };
 
 // TCP connection flow entry
@@ -58,11 +72,16 @@ struct flow_data_t {
     __u32 last_ack[2];
     // Retransmit Counters (Also catches duplicates and out-of-order packets)
     __u16 tcp_retransmits[2];
+    // Padding to avoid 4 byte hole and push TSval/TSecr data to its own cacheline
+    // Would probably be better to increase the tcp_retransmit counters to u32
+    // instead, but that requires additional changes to all the user-space Rust
+    // code that use them.
+    __u32 pad1;
     // Timestamp values
     __u32 tsval[2];
     __u32 tsecr[2];
     // When did the timestamp change?
-    __u64 ts_change_time[2];
+    struct tsval_record_buffer_t tsval_tstamps[2];
     // Has the connection ended?
     // 0 = Alive, 1 = FIN, 2 = RST
     __u8 end_status;
@@ -71,7 +90,7 @@ struct flow_data_t {
     // IP Flags
     __u8 ip_flags;
     // Padding
-    __u8 pad;
+    __u8 pad2[5];
 };
 
 // Map for tracking TCP flow progress.
@@ -118,7 +137,7 @@ static __always_inline struct flow_data_t new_flow_data(
         .tcp_retransmits = { 0, 0 },
         .tsval = { 0, 0 },
         .tsecr = { 0, 0 },
-        .ts_change_time = { 0, 0 },
+        .tsval_tstamps = { { 0 }, { 0 } },
         .end_status = 0,
         .tos = 0,
         .ip_flags = 0,
@@ -259,6 +278,59 @@ static __always_inline void detect_retries(
     data->last_ack[rate_index] = ack_seq;
 }
 
+// Add a TSval <-> timestamp mapping to buf.
+// Will overwrite outdated (timed out) entries.
+// Will return 0 on success, or -1 if there was no free slot in buf.
+static __always_inline int record_tsval(
+    struct tsval_record_buffer_t *buf,
+    __u64 time,
+    __u32 tsval
+) {
+    int i;
+
+    for (i = 0; i < ARRAY_SIZE(buf->timestamps); i++) {
+        if (
+            buf->timestamps[i] == 0 || // This spot has no recorded TSval
+            buf->timestamps[i] + TIMEOUT_TSVAL_NS < time // This spot has an old/stale recorded TSval
+        ) {
+            buf->timestamps[i] = time;
+            buf->tsvals[i] = tsval;
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+// Check if tsval has any matching recorded entry in buf.
+// Will clear any outdated entries, as well as the entry it matches in buf
+// On success, return the time the matched TSval was recorded.
+// Return 0 if no matching entry was found.
+static __always_inline __u64 match_and_clear_recorded_tsval(
+    struct tsval_record_buffer_t *buf,
+    __u32 tsval
+) {
+    __u64 match_at_time = 0;
+    int i;
+
+    for (i = 0; i < ARRAY_SIZE(buf->timestamps); i++) {
+        if (buf->timestamps[i] == 0)
+            // Empty entry
+            continue;
+
+        if (buf->tsvals[i] == tsval) {
+            // Match - return time of match and clear out entry
+            match_at_time = buf->timestamps[i];
+            buf->timestamps[i] = 0;
+	    // No early return to let is also clear out old entries
+        } else if (u32wrap_lt(buf->tsvals[i], tsval)) {
+            // Old TSval which we've already passed - clear out
+            buf->timestamps[i] = 0;
+        }
+    }
+
+    return match_at_time;
+}
 
 // Passively infer TCP RTT by matching ACKs to previous TCP segments using TCP
 // timestamps (TSval/TSecr).
@@ -285,7 +357,7 @@ static __always_inline void infer_tcp_rtt(
         u32wrap_lt(data->tsval[rate_index], dissector->tsval) // New TSval
     ) {
         data->tsval[rate_index] = dissector->tsval;
-        data->ts_change_time[rate_index] = dissector->now;
+        record_tsval(&data->tsval_tstamps[rate_index], dissector->now, dissector->tsval);
     }
 
     if (dissector->tsecr == 0)
@@ -299,8 +371,10 @@ static __always_inline void infer_tcp_rtt(
         data->tsecr[rate_index] = dissector->tsecr;
 
         // Match TSecr against previous TSval in reverse direction
-        if (dissector->tsecr == data->tsval[other_rate_index]) {
-            __u64 elapsed = dissector->now - data->ts_change_time[other_rate_index];
+        __u64 match_at = match_and_clear_recorded_tsval(
+            &data->tsval_tstamps[other_rate_index], dissector->tsecr);
+        if (match_at > 0) {
+            __u64 elapsed = dissector->now - match_at;
             if (elapsed < TWO_SECONDS_IN_NANOS) {
                 struct flowbee_event event = { 0 };
                 event.key = *key;

--- a/src/rust/lqos_sys/src/bpf/common/flows.h
+++ b/src/rust/lqos_sys/src/bpf/common/flows.h
@@ -272,11 +272,8 @@ static __always_inline void infer_tcp_rtt(
     //bpf_debug("[FLOWS][%d] TSVAL: %u, TSECR: %u", direction, tsval, tsecr);
     if (dissector->tsval != data->tsval[rate_index] && dissector->tsecr != data->tsecr[rate_index]) {
 
-        if (
-            dissector->tsecr == data->tsval[other_rate_index] &&
-            (data->rate_estimate_bps[rate_index] > 0 ||
-             data->rate_estimate_bps[other_rate_index] > 0 )
-        ) {
+        // Match check
+        if (dissector->tsecr == data->tsval[other_rate_index]) {
             __u64 elapsed = dissector->now - data->ts_change_time[other_rate_index];
             if (elapsed < TWO_SECONDS_IN_NANOS) {
                 struct flowbee_event event = { 0 };

--- a/src/rust/lqos_sys/src/bpf/common/flows.h
+++ b/src/rust/lqos_sys/src/bpf/common/flows.h
@@ -9,7 +9,6 @@
 
 
 #define SECOND_IN_NANOS 1000000000ULL
-#define TWO_SECONDS_IN_NANOS 2000000000
 #define MS_IN_NANOS_T10 10000
 #define HALF_MBPS_IN_BYTES_PER_SECOND 62500
 #define RTT_RING_SIZE 4
@@ -396,13 +395,12 @@ static __always_inline void infer_tcp_rtt(
             &data->tsval_tstamps[other_rate_index], dissector->tsecr);
         if (match_at > 0) {
             __u64 elapsed = dissector->now - match_at;
-            if (elapsed < TWO_SECONDS_IN_NANOS) {
-                struct flowbee_event event = { 0 };
-                event.key = *key;
-                event.round_trip_time = elapsed;
-                event.effective_direction = other_rate_index; // direction of the origial TCP segment we matched against
-                bpf_ringbuf_output(&flowbee_events, &event, sizeof(event), 0);
-            }
+
+            struct flowbee_event event = { 0 };
+            event.key = *key;
+            event.round_trip_time = elapsed;
+            event.effective_direction = other_rate_index; // direction of the origial TCP segment we matched against
+            bpf_ringbuf_output(&flowbee_events, &event, sizeof(event), 0);
         }
     }
 

--- a/src/rust/lqos_sys/src/flowbee_data.rs
+++ b/src/rust/lqos_sys/src/flowbee_data.rs
@@ -60,6 +60,8 @@ pub struct FlowbeeData {
     /// When did the timestamp change?
     /// Dummy data type - just to match 24-byte size and 8-byte alignment
     pub tsval_tstamps: DownUpOrder<[u64; 3]>,
+    /// Last time we pushed an RTT sample
+    pub last_rtt: DownUpOrder<u64>,
     /// Has the connection ended?
     /// 0 = Alive, 1 = FIN, 2 = RST
     pub end_status: u8,

--- a/src/rust/lqos_sys/src/flowbee_data.rs
+++ b/src/rust/lqos_sys/src/flowbee_data.rs
@@ -51,12 +51,15 @@ pub struct FlowbeeData {
     pub last_ack: DownUpOrder<u32>,
     /// TCP Retransmission count (also counts duplicates)
     pub tcp_retransmits: DownUpOrder<u16>,
+    /// Padding to avoid 4-byte hole and push TSval/TSecr entries to new cacheline
+    pub padding1: u32,
     /// Timestamp values
     pub tsval: DownUpOrder<u32>,
     /// Timestamp echo values
     pub tsecr: DownUpOrder<u32>,
     /// When did the timestamp change?
-    pub ts_change_time: DownUpOrder<u64>,
+    /// Dummy data type - just to match 24-byte size and 8-byte alignment
+    pub tsval_tstamps: DownUpOrder<[u64; 3]>,
     /// Has the connection ended?
     /// 0 = Alive, 1 = FIN, 2 = RST
     pub end_status: u8,
@@ -65,5 +68,5 @@ pub struct FlowbeeData {
     /// Raw TCP flags
     pub flags: u8,
     /// Padding.
-    pub padding: u8,
+    pub padding2: [u8; 5],
 }


### PR DESCRIPTION
This PR contains a number of fixes for the eBPF code responsible for passivly inferring TCP RTTs. The two biggest changes are that it no longer tries to track RTTs for pure ACKs (as the originating packet), and that it keeps tracks of up to two previous TSvals instead of only attempting to match packets to the last seen TSval. Each commit message contains further explanation and motivation for the fixes/changes.

I have tested these changes in a virtual setup, with two veth-devices connected to different namesspaces as illustrated in the figure below, using netem to simulate some latency on each side. What in the figure is denoted as "local RTT" is what is currently tracked as "RTT up"  and what is shown as the external RTT is currently "RTT down" (I prupose switching these around in one of the commits).
![test_setup drawio](https://github.com/user-attachments/assets/1b374068-b2ec-4e21-adb7-4af834b201bd)

As I make some fairly large modifications to the RTT logic as a whole, I've done some performance tests using 10, 100 and 1000 concurrent iperf3 flows (evenly distributed across 10 IPs, of which 8 are shaped). The flows are purly downlink (I used `iperf3 --reverse`, so the iperf3 servers in the figure above are the senders). The flows run for 1 minute and I repeat the test 5 times. These are the results before introducing the changes:
| Flows | run time - to-lan (ns)        | run time - to-wan (ns)        | RTTs (reported) - to-lan | RTTs (reported) - to-wan |
|-------|-------------------------------|-------------------------------|--------------------------|--------------------------|
| 10    | 459.7,453.7,456.5,412.5,456.0 | 271.5,273.4,271.1,254.6,272.0 | 5125 (5125)              | 235 (235)                |
| 100   | 539.3,539.2,544.3,553.0,544.8 | 349.0,352.2,355.4,357.3,354.6 | 38920 (38920)            | 6269 (6269)              |
| 1000  | 817,1,808.5,804.7,804.6,813.9 | 473.9,472.5,472.2,474.5,475.8 | 1680884 (1680844)        | 486304 (486248)          |

The run time numbers is the average execution time in nanoseconds for the XDP program on each interface, as measured by `sysctl kernel.bpf_stats_enabled=1` (the cumulative runtime divided by the run count). I included the measurements from all 5 individual runs to give a sense of the variability between runs. The number of RTTs is taken from some counters I added in eBPF programs (can be found in my dirty branch [here](https://github.com/simosund/LibreQoS/tree/ebpf-rtt-fixes-dirty), the RTT counts are from a separate set of runs to avoid the added counters from impacting the performance). The number outside of the parentheses are the number of RTTs actually captured by the eBPF RTT logic, with the number inside parentheses showing the number of these that are actually pushed to user space via the perf-buffer. Currently there's not much of a difference beteween the two as the only "filter" is to not report RTTs above 2 seconds to user space, but this changes after the changes introduced in this PR where I also introduce a rate limit to the number of RTTs reported per flow.

These are the results after all of the changes in this PR being applied:
| Flows | run time - to-lan (ns)        | run time - to-wan (ns)        | RTTs (reported) - to-lan | RTTs (reported) - to-wan |
|-------|-------------------------------|-------------------------------|--------------------------|--------------------------|
| 10    | 538.7,474.6,458.1,461.5,477.3 | 318.6,280.3,273.6,270.1,280.8 | 277743 (14722)           | 64 (64)                  |
| 100   | 597.4,591.0,580.3,583.4,587.7 | 370.2,366.1,359.1,361.3,366.9 | 2223298 (135594)         | 111 (106)                |
| 1000  | 812.1,805.6,803.6,800.1,800.3 | 449.5,449.4,448.2,450.4,448.3 | 8271012 (1178804)        | 493 (444)                |

In terms of performance, the overhead is considerably higher after the changes for the 10 and 100 concurrent flow cases, but slightly lower for the 1000 flow case. I think a large part of the performance difference comes down to the numbers of RTTs that are actually pushed to user space via the perf buffer. 

As can be noted, on the "to-lan" side (which will capture "local RTTs") after the change we end up reporting many more RTTs for the 10 and 100 flow cases, while we end up reporting a bit fewer RTTs for the 1000 flow case (note however that the new logic always detects more RTTs, it's just the added RTT sample rate limiting preventing it from pushing all RTT samples to user space to reduce load). On the "to-wan" side (which will capture the "external RTTs in the figure above) the new logic gets much fewer RTT samples, which is a result of no longer trying to produce RTTs with pure ACKs as the initial packet, and is expected as the the data traffic is almost entierly unidirectional in this setup (outside of some short communication between the iperf3 client and server at the start and end of the test).

Finally, these changes does increase the size of the tracked per-flow state in the `flow_data_t` struct. This is the current struct layout before these changes:
```console
$ pahole -C flow_data_t src/rust/target/debug/build/lqos_sys-0352d423ceed744f/out/lqos_kern.o
struct flow_data_t {
        __u64                      start_time;           /*     0     8 */
        __u64                      last_seen;            /*     8     8 */
        __u64                      bytes_sent[2];        /*    16    16 */
        __u64                      packets_sent[2];      /*    32    16 */
        __u64                      next_count_time[2];   /*    48    16 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        __u64                      last_count_time[2];   /*    64    16 */
        __u64                      next_count_bytes[2];  /*    80    16 */
        __u32                      rate_estimate_bps[2]; /*    96     8 */
        __u32                      last_sequence[2];     /*   104     8 */
        __u32                      last_ack[2];          /*   112     8 */
        __u16                      tcp_retransmits[2];   /*   120     4 */
        __u32                      tsval[2];             /*   124     8 */
        /* --- cacheline 2 boundary (128 bytes) was 4 bytes ago --- */
        __u32                      tsecr[2];             /*   132     8 */

        /* XXX 4 bytes hole, try to pack */

        __u64                      ts_change_time[2];    /*   144    16 */
        __u8                       end_status;           /*   160     1 */
        __u8                       tos;                  /*   161     1 */
        __u8                       ip_flags;             /*   162     1 */
        __u8                       pad;                  /*   163     1 */

        /* size: 168, cachelines: 3, members: 18 */
        /* sum members: 160, holes: 1, sum holes: 4 */
        /* padding: 4 */
        /* last cacheline: 40 bytes */
};
```

And this is the layout after the changes in this PR:
```console
$ pahole -C flow_data_t rust/target/debug/build/lqos_sys-0352d423ceed744f/out/lqos_kern.o
struct flow_data_t {
        __u64                      start_time;           /*     0     8 */
        __u64                      last_seen;            /*     8     8 */
        __u64                      bytes_sent[2];        /*    16    16 */
        __u64                      packets_sent[2];      /*    32    16 */
        __u64                      next_count_time[2];   /*    48    16 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        __u64                      last_count_time[2];   /*    64    16 */
        __u64                      next_count_bytes[2];  /*    80    16 */
        __u32                      rate_estimate_bps[2]; /*    96     8 */
        __u32                      last_sequence[2];     /*   104     8 */
        __u32                      last_ack[2];          /*   112     8 */
        __u16                      tcp_retransmits[2];   /*   120     4 */
        __u32                      pad1;                 /*   124     4 */
        /* --- cacheline 2 boundary (128 bytes) --- */
        __u32                      tsval[2];             /*   128     8 */
        __u32                      tsecr[2];             /*   136     8 */
        struct tsval_record_buffer_t tsval_tstamps[2];   /*   144    48 */
        /* --- cacheline 3 boundary (192 bytes) --- */
        __u64                      last_rtt[2];          /*   192    16 */
        __u8                       end_status;           /*   208     1 */
        __u8                       tos;                  /*   209     1 */
        __u8                       ip_flags;             /*   210     1 */
        __u8                       pad2[5];              /*   211     5 */

        /* size: 216, cachelines: 4, members: 20 */
        /* last cacheline: 24 bytes */
};
```

So these changes overall increase the size from 168 bytes (of which 5 bytes are padding) to 216 bytes (of which 9 bytes are padding), pushing it from 3 to 4 cache lines. So this may degrade cache performance a bit, although at least the test with 1000 concurrent flows seems to indicate that it doesn't hurt the overall performance on my machine.

Let me know if any aspects of my pruposed changes are unclear. I'm willing to make further changes to this PR if there are certain aspects you have concerns with. It would of course also be great if you could test these changes in whatever setup you use for testing LibreQoS.