### PR TITLE
Add "disable_icmp_ping" config option, disabling device pinging from the circuit page.

### DIFF
--- a/src/rust/lqos_config/src/etc/v15/top_config.rs
+++ b/src/rust/lqos_config/src/etc/v15/top_config.rs
@@ -84,6 +84,9 @@ pub struct Config {
     
     /// Support for Tornado/Auto-rate.
     pub stormguard: Option<stormguard::StormguardConfig>,
+
+    /// Disable ICMP Ping Monitoring for Devices in the hosts view
+    pub disable_icmp_ping: Option<bool>,
 }
 
 impl Config {
@@ -159,6 +162,7 @@ impl Default for Config {
             disable_webserver: None,
             webserver_listen: None,
             stormguard: None,
+            disable_icmp_ping: Some(false),
         }
     }
 }

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_general.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_general.js
@@ -39,6 +39,7 @@ function updateConfig() {
     window.config.packet_capture_time = parseInt(document.getElementById("packetCaptureTime").value);
     window.config.queue_check_period_ms = parseInt(document.getElementById("queueCheckPeriod").value);
     window.config.disable_webserver = document.getElementById("disableWebserver").checked;
+    window.config.disable_icmp_ping = document.getElementById("disableIcmpPing").checked;
     
     const webserverListen = document.getElementById("webserverListen").value.trim();
     window.config.webserver_listen = webserverListen ? webserverListen : null;
@@ -68,6 +69,7 @@ loadConfig(() => {
         // Optional fields with nullish coalescing
         document.getElementById("disableWebserver").checked = window.config.disable_webserver ?? false;
         document.getElementById("webserverListen").value = window.config.webserver_listen ?? "";
+        document.getElementById("disableIcmpPing").checked = window.config.disable_icmp_ping ?? false;
 
         // Add save button click handler
         document.getElementById('saveButton').addEventListener('click', () => {

--- a/src/rust/lqosd/src/node_manager/static2/config_general.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_general.html
@@ -35,6 +35,12 @@
                 <div class="form-text">Leave blank for default (0.0.0.0:9123)</div>
             </div>
 
+            <div class="mb-3 form-check">
+                <input type="checkbox" class="form-check-input" id="disableIcmpPing">
+                <label class="form-check-label" for="disableIcmpPing">Disable ICMP Ping</label>
+                <div class="form-text">Disable ICMP ping monitoring for devices in the hosts view</div>
+            </div>
+
             <button type="button" id="saveButton" class="btn btn-outline-primary">Save Changes</button>
         </form>
     </div>

--- a/src/rust/lqosd/src/node_manager/ws/single_user_channels/ping_monitor.rs
+++ b/src/rust/lqosd/src/node_manager/ws/single_user_channels/ping_monitor.rs
@@ -23,6 +23,16 @@ pub(super) async fn ping_monitor(
     ip_addresses: Vec<(String, String)>,
     tx: tokio::sync::mpsc::Sender<String>,
 ) {
+    {
+        let Ok(cfg) = lqos_config::load_config() else {
+            error!("Failed to load configuration for ping monitor");
+            return;
+        };
+        if cfg.disable_icmp_ping.unwrap_or(false) {
+            info!("ICMP ping is disabled in the configuration, not starting ping monitor");
+            return;
+        }
+    }
     let mut ticker = tokio::time::interval(Duration::from_secs(1));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
     loop {


### PR DESCRIPTION
Feat: Adds `disable_icmp_ping` and web control to the configuration. If set, the `pinger` on the circuit/devices page won't run pings.