### PR TITLE
Issue 732 second try - multiple items

### DIFF
--- a/src/LibreQoS.py
+++ b/src/LibreQoS.py
@@ -1103,7 +1103,8 @@ def refreshShapers():
 		
 		
 		# Clear Prior Settings
-		clearPriorSettings(interface_a(), interface_b())
+		# We don't want to do this every time, with lqosd managing queues statefully.
+		# clearPriorSettings(interface_a(), interface_b())
 
 		
 		# Setup XDP and disable XPS regardless of whether it is first run or not (necessary to handle cases where systemctl stop was used)

--- a/src/rust/lqos_bakery/src/commands.rs
+++ b/src/rust/lqos_bakery/src/commands.rs
@@ -298,7 +298,7 @@ command = 'class add dev ' + interface_b() + ' parent ' + data[node]['up_parentC
          */
 
         result.push(vec![
-            "class".to_string(), "add".to_string(), "dev".to_string(), config.isp_interface(),
+            "class".to_string(), "replace".to_string(), "dev".to_string(), config.isp_interface(),
             "parent".to_string(), parent_class_id.as_tc_string(),
             "classid".to_string(), format!("0x{class_minor:x}"), "htb".to_string(),
             "rate".to_string(), format_rate_for_tc_f32(download_bandwidth_min),
@@ -310,7 +310,7 @@ command = 'class add dev ' + interface_b() + ' parent ' + data[node]['up_parentC
             ),
         ]);
         result.push(vec![
-            "class".to_string(), "add".to_string(), "dev".to_string(), config.internet_interface(),
+            "class".to_string(), "replace".to_string(), "dev".to_string(), config.internet_interface(),
             "parent".to_string(), up_parent_class_id.as_tc_string(),
             "classid".to_string(), format!("0x{class_minor:x}"),
             "htb".to_string(), "rate".to_string(), format_rate_for_tc_f32(upload_bandwidth_min),
@@ -400,7 +400,7 @@ if monitor_mode_only() == False:
  */
         if do_htb {
             result.push(vec![
-                "class".to_string(), "add".to_string(), "dev".to_string(), config.isp_interface(),
+                "class".to_string(), "replace".to_string(), "dev".to_string(), config.isp_interface(),
                 "parent".to_string(), parent_class_id.as_tc_string(),
                 "classid".to_string(), format!("0x{class_minor:x}"), "htb".to_string(),
                 "rate".to_string(), format_rate_for_tc_f32(download_bandwidth_min),
@@ -414,7 +414,7 @@ if monitor_mode_only() == False:
         }
         if !config.queues.monitor_only && do_sqm {
             let mut sqm_command = vec![
-                "qdisc".to_string(), "add".to_string(), "dev".to_string(),
+                "qdisc".to_string(), "replace".to_string(), "dev".to_string(),
                 config.isp_interface(),
                 "parent".to_string(), format!("0x{:x}:0x{:x}", class_major, class_minor),
             ];
@@ -424,7 +424,7 @@ if monitor_mode_only() == False:
 
         if do_htb {
             result.push(vec![
-                "class".to_string(), "add".to_string(), "dev".to_string(), config.internet_interface(),
+                "class".to_string(), "replace".to_string(), "dev".to_string(), config.internet_interface(),
                 "parent".to_string(), up_parent_class_id.as_tc_string(),
                 "classid".to_string(), format!("0x{class_minor:x}"),
                 "htb".to_string(), "rate".to_string(), format_rate_for_tc_f32(upload_bandwidth_min),
@@ -439,7 +439,7 @@ if monitor_mode_only() == False:
 
         if !config.queues.monitor_only && do_sqm {
             let mut sqm_command = vec![
-                "qdisc".to_string(), "add".to_string(), "dev".to_string(),
+                "qdisc".to_string(), "replace".to_string(), "dev".to_string(),
                 config.internet_interface(),
                 "parent".to_string(), format!("0x{:x}:0x{:x}", up_class_major, class_minor),
             ];

--- a/src/rust/lqos_bakery/src/lib.rs
+++ b/src/rust/lqos_bakery/src/lib.rs
@@ -473,6 +473,16 @@ fn handle_change_site_speed_live(
         let to_isp = config.isp_interface();
         let class_id = format!("0x{:x}:0x{:x}", parent_class_id.get_major_minor().0, class_minor);
         let up_class_id = format!("0x{:x}:0x{:x}", up_parent_class_id.get_major_minor().0, class_minor);
+        let upload_bandwidth_min = if upload_bandwidth_min >= (upload_bandwidth_max-0.5) {
+            upload_bandwidth_max - 1.0
+        } else {
+            upload_bandwidth_min
+        };
+        let download_bandwidth_min = if download_bandwidth_min >= (download_bandwidth_max-0.5) {
+            download_bandwidth_max - 1.0
+        } else {
+            download_bandwidth_min
+        };
         let commands = vec![vec![
             "class".to_string(),
             "change".to_string(),

--- a/src/rust/lqos_bakery/src/lib.rs
+++ b/src/rust/lqos_bakery/src/lib.rs
@@ -416,7 +416,6 @@ fn handle_change_site_speed_live(
         let class_id = format!("0x{:x}:0x{:x}", parent_class_id.get_major_minor().0, class_minor);
         let up_class_id = format!("0x{:x}:0x{:x}", up_parent_class_id.get_major_minor().0, class_minor);
         let commands = vec![vec![
-            "tc".to_string(),
             "class".to_string(),
             "change".to_string(),
             "dev".to_string(),
@@ -429,7 +428,6 @@ fn handle_change_site_speed_live(
             "ceil".to_string(),
             format_rate_for_tc_f32(upload_bandwidth_max),
         ], vec![
-            "tc".to_string(),
             "class".to_string(),
             "change".to_string(),
             "dev".to_string(),

--- a/src/rust/lqos_bakery/src/lib.rs
+++ b/src/rust/lqos_bakery/src/lib.rs
@@ -524,6 +524,7 @@ fn handle_change_site_speed_live(
 }
 
 fn full_reload(batch: &mut Option<Vec<Arc<BakeryCommands>>>, sites: &mut HashMap<i64, Arc<BakeryCommands>>, circuits: &mut HashMap<i64, Arc<BakeryCommands>>, live_circuits: &mut HashMap<i64, u64>, config: &Arc<Config>, new_batch: Vec<Arc<BakeryCommands>>) {
+    warn!("Bakery: Full reload triggered due to site or circuit changes.");
     sites.clear();
     circuits.clear();
     live_circuits.clear();

--- a/src/rust/lqos_bakery/src/lib.rs
+++ b/src/rust/lqos_bakery/src/lib.rs
@@ -233,11 +233,6 @@ fn handle_commit_batch(
     // Declare any site speed changes that need to be applied. We're sending them
     // to ourselves as future commands via the BakeryCommands channel.
     if let SiteDiffResult::SpeedChanges { changes } = site_change_mode {
-        if changes.is_empty() {
-            debug!("No speed changes detected, skipping processing.");
-            return;
-        }
-
         for change in &changes {
             let BakeryCommands::AddSite { site_hash, download_bandwidth_min, upload_bandwidth_min, download_bandwidth_max, upload_bandwidth_max, .. } = change else {
                 warn!("ChangeSiteSpeedLive received a non-site command: {:?}", change);

--- a/src/rust/lqos_bakery/src/lib.rs
+++ b/src/rust/lqos_bakery/src/lib.rs
@@ -216,6 +216,10 @@ fn handle_commit_batch(
         info!("No changes detected in batch, skipping processing.");
         return;
     }
+    
+    // Detect if this is a speed-only update
+    let is_speed_only_update = matches!(site_change_mode, SiteDiffResult::SpeedChanges { .. }) 
+        && matches!(circuit_change_mode, diff::CircuitDiffResult::NoChange);
 
     // Check if we should do a full reload based on the number of circuit changes
     if let diff::CircuitDiffResult::CircuitsChanged { newly_added, removed_circuits, updated_circuits } = &circuit_change_mode {
@@ -333,6 +337,10 @@ fn handle_commit_batch(
             }
         }
     }
+    
+    // Process the batch at the end, but skip MQ setup if this is a speed-only update
+    process_batch_with_options(new_batch, &config, sites, circuits, is_speed_only_update);
+    *batch = None;
 }
 
 fn handle_circuit_activity(
@@ -538,11 +546,27 @@ fn process_batch(
     sites: &mut HashMap<i64, Arc<BakeryCommands>>,
     circuits: &mut HashMap<i64, Arc<BakeryCommands>>,
 ) {
-    info!("Bakery: Processing batch of {} commands", batch.len());
+    process_batch_with_options(batch, config, sites, circuits, false);
+}
+
+fn process_batch_with_options(
+    batch: Vec<Arc<BakeryCommands>>,
+    config: &Arc<lqos_config::Config>,
+    sites: &mut HashMap<i64, Arc<BakeryCommands>>,
+    circuits: &mut HashMap<i64, Arc<BakeryCommands>>,
+    skip_mq_setup: bool,
+) {
+    info!("Bakery: Processing batch of {} commands (skip_mq_setup: {})", batch.len(), skip_mq_setup);
     let mut circuit_count = 0u64;
     let commands = batch
         .into_iter()
-        .map(|b| {
+        .filter_map(|b| {
+            // Skip MqSetup commands if we're in speed-only update mode
+            if skip_mq_setup && matches!(b.as_ref(), BakeryCommands::MqSetup { .. }) {
+                info!("Skipping MQ setup during speed-only update");
+                return None;
+            }
+            
             // Ensure that our state map is up to date with the latest commands
             match b.as_ref() {
                 BakeryCommands::AddSite { site_hash, .. } => {
@@ -554,7 +578,7 @@ fn process_batch(
                 }
                 _ => {}
             }
-            b.to_commands(config, ExecutionMode::Builder)
+            Some(b.to_commands(config, ExecutionMode::Builder))
         })
         .flatten()
         .flatten()

--- a/src/rust/lqos_bakery/src/lib.rs
+++ b/src/rust/lqos_bakery/src/lib.rs
@@ -204,6 +204,7 @@ fn handle_commit_batch(
         // If the site structure has changed, we need to rebuild everything.
         info!("Site structure has changed, performing full reload.");
         full_reload(batch, sites, circuits, live_circuits, &config, new_batch);
+        MQ_CREATED.store(true, std::sync::atomic::Ordering::Relaxed);
         return;
     }
 

--- a/src/rust/lqos_bakery/src/utils.rs
+++ b/src/rust/lqos_bakery/src/utils.rs
@@ -39,10 +39,9 @@ pub(crate) fn execute_in_memory(command_buffer: &Vec<Vec<String>>, purpose: &str
         error!("Command output for ({purpose}): {:?}", output_str.trim());
     }
 
-    let error_str = String::from_utf8_lossy(&output.stderr)
-        .replace("Error: Exclusivity flag on, cannot modify.\n", "");
+    let error_str = String::from_utf8_lossy(&output.stderr);
     if !error_str.is_empty() {
-        let message = format!("Command error for ({purpose}): {:?}.\n{lines}", error_str.trim());
+        let message = format!("Command error for ({purpose}): {:?}.Error: {error_str}\n{lines}", error_str.trim());
         error!(message);
     }
 

--- a/src/rust/lqos_bakery/src/utils.rs
+++ b/src/rust/lqos_bakery/src/utils.rs
@@ -28,19 +28,21 @@ pub(crate) fn execute_in_memory(command_buffer: &Vec<Vec<String>>, purpose: &str
             .args(&["-f", "-batch", path.to_str().unwrap()])
             .output()
     else {
-        let message = format!("Failed to execute tc batch command for {purpose}. Command output:\n {}", lines);
+        let message = format!("Failed to execute tc batch command for {purpose}.");
         error!(message);
         return;
     };
 
-    let output_str = String::from_utf8_lossy(&output.stdout);
+    let output_str = String::from_utf8_lossy(&output.stdout)
+        .replace("Error: Exclusivity flag on, cannot modify.\n", "");
     if !output_str.is_empty() {
         error!("Command output for ({purpose}): {:?}", output_str.trim());
     }
 
-    let error_str = String::from_utf8_lossy(&output.stderr);
+    let error_str = String::from_utf8_lossy(&output.stderr)
+        .replace("Error: Exclusivity flag on, cannot modify.\n", "");
     if !error_str.is_empty() {
-        let message = format!("Command error for ({purpose}): {:?}. Command:\n{}", error_str.trim(), lines);
+        let message = format!("Command error for ({purpose}): {:?}.\n{lines}", error_str.trim());
         error!(message);
     }
 

--- a/src/rust/lqosd/src/main.rs
+++ b/src/rust/lqosd/src/main.rs
@@ -63,7 +63,7 @@ use crate::throughput_tracker::flow_data::{ALL_FLOWS, RECENT_FLOWS};
 use tracing::level_filters::LevelFilter;
 use lqos_stormguard::STORMGUARD_STATS;
 
-// Use JemAllocator only on supported platforms
+// Use MiMalloc only on supported platforms
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;

--- a/src/rust/lqosd/src/node_manager/js_build/src/graphs/packets_bar_insight.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/graphs/packets_bar_insight.js
@@ -115,14 +115,14 @@ export class PacketsPerSecondTimescale extends DashboardGraph {
 
             for (let x=0; x<data.length; x++) {
                 this.option.xAxis.data.push(data[x].time);
-                seriesTcpDown.data.push(data[x].median_tcp_down);
-                SeriesTcpUp.data.push((0.0 - data[x].median_tcp_up));
+                seriesTcpDown.data.push(data[x].max_tcp_down);
+                SeriesTcpUp.data.push((0.0 - data[x].max_tcp_up));
 
-                seriesUdpDown.data.push(data[x].median_udp_down);
-                SeriesUdpUp.data.push((0.0 - data[x].median_udp_up));
+                seriesUdpDown.data.push(data[x].max_udp_down);
+                SeriesUdpUp.data.push((0.0 - data[x].max_udp_up));
 
-                seriesIcmpDown.data.push(data[x].median_icmp_down);
-                SeriesIcmpUp.data.push((0.0 - data[x].median_icmp_up));
+                seriesIcmpDown.data.push(data[x].max_icmp_down);
+                SeriesIcmpUp.data.push((0.0 - data[x].max_icmp_up));
             }
 
             this.option.series.push(seriesTcpDown);

--- a/src/rust/lqosd/src/node_manager/js_build/src/lq_js_common/dashboard/dashboard_editor.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/lq_js_common/dashboard/dashboard_editor.js
@@ -163,6 +163,9 @@ export function openDashboardEditor(initialElements, availableElements, callback
             put: true
         },
         onAdd: function (evt) {
+            // Remove any placeholder before adding new content
+            $('#dashboardGrid .dashboard-item[data-name="placeholder"]').remove();
+            
             // When an item is dropped into the grid (from the available list),
             // replace it with a fully rendered dashboard item.
             var $item = $(evt.item);
@@ -204,6 +207,18 @@ export function openDashboardEditor(initialElements, availableElements, callback
     // Handle delete action for dashboard items.
     $('#dashboardGrid').on('click', '.delete-item', function() {
         $(this).closest('.dashboard-item').remove();
+        // If we removed the last item, add a placeholder
+        if ($('#dashboardGrid .dashboard-item').length === 0) {
+            $('#dashboardGrid').append(`
+                <div class="dashboard-item col-12" data-size="12" data-name="placeholder">
+                    <div class="card border-dashed h-100">
+                        <div class="card-body d-flex justify-content-center align-items-center">
+                            <span class="text-muted">Drag widgets here to start building your dashboard</span>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }
     });
 
     // Handle clear all action

--- a/src/rust/lqosd/src/throughput_tracker/flow_data/netflow5/mod.rs
+++ b/src/rust/lqosd/src/throughput_tracker/flow_data/netflow5/mod.rs
@@ -19,6 +19,15 @@ impl Netflow5 {
         std::thread::Builder::new()
             .name("Netflow5".to_string())
             .spawn(move || {
+                // Create socket once and reuse it
+                let socket = match UdpSocket::bind("0.0.0.0:0") {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::error!("Failed to create Netflow5 UDP socket: {}", e);
+                        return;
+                    }
+                };
+
                 let sequence = AtomicU32::new(0);
                 let mut accumulator = Vec::with_capacity(15);
                 let mut last_sent = std::time::Instant::now();
@@ -30,10 +39,6 @@ impl Netflow5 {
 
                     accumulator.push((key, (data, analysis)));
 
-                    let Ok(socket) = UdpSocket::bind("0.0.0.0:0") else {
-                        tracing::error!("Failed to bind to UDP socket");
-                        continue;
-                    };
                     // Send if there is more than 15 records AND it has been more than 1 second since the last send
                     if accumulator.len() >= 15 && last_sent.elapsed().as_secs() > 1 {
                         for chunk in accumulator.chunks(15) {
@@ -41,6 +46,13 @@ impl Netflow5 {
                         }
                         accumulator.clear();
                         last_sent = std::time::Instant::now();
+                    }
+                }
+                
+                // Handle any remaining flows when shutting down
+                if !accumulator.is_empty() {
+                    for chunk in accumulator.chunks(15) {
+                        Self::queue_handler(chunk, &socket, &target, &sequence);
                     }
                 }
             })?;
@@ -88,7 +100,11 @@ impl Netflow5 {
             }
         }
 
-        socket.send_to(&buffer, target).unwrap();
-        sequence.fetch_add(num_records as u32, std::sync::atomic::Ordering::Relaxed);
+        if let Err(e) = socket.send_to(&buffer, target) {
+            tracing::error!("Failed to send Netflow5 data to {}: {}", target, e);
+            // Don't increment sequence on failure to maintain consistency
+        } else {
+            sequence.fetch_add(num_records as u32, std::sync::atomic::Ordering::Relaxed);
+        }
     }
 }

--- a/src/rust/lqosd/src/throughput_tracker/flow_data/netflow9/mod.rs
+++ b/src/rust/lqosd/src/throughput_tracker/flow_data/netflow9/mod.rs
@@ -16,7 +16,7 @@ impl Netflow9 {
     ) -> anyhow::Result<Sender<(FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>> {
         let (tx, rx) =
             crossbeam_channel::bounded::<(FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>(65535);
-        let socket = UdpSocket::bind("0.0.0.0:12212")?;
+        let socket = UdpSocket::bind("0.0.0.0:0")?;
 
         std::thread::Builder::new()
             .name("Netflow9".to_string())

--- a/src/rust/lqosd/src/throughput_tracker/mod.rs
+++ b/src/rust/lqosd/src/throughput_tracker/mod.rs
@@ -131,7 +131,13 @@ fn throughput_task(
     };
 
     let mut last_submitted_to_lts: Option<Instant> = None;
-    let mut tfd = TimerFd::new().unwrap();
+    let mut tfd = match TimerFd::new() {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!("Failed to create timer for throughput monitor: {}", e);
+            return;
+        }
+    };
     assert_eq!(tfd.get_state(), TimerState::Disarmed);
     tfd.set_state(
         TimerState::Periodic {


### PR DESCRIPTION
FIXES #732 and #731 

Sorry that this PR messes up the one-issue-per-PR policy, found a few somewhat-linked issues and tackled them together.

* Flow tracking system now properly re-uses UDP sockets to prevent netflow 5/9 exhaustion (big speedup and memory improvement)
* Flow tracking system now uses a much lighter-weight transmission system for control signals.
* Netflow 9 no longer tries to bind to a specified local port number, it lets the OS pick.
* Better error handling in the flow tracker.
* A placeholder is added to empty dashboards so there's a drop target to add items.
* Fixed the packets display on Insight-enabled time graphs.
* If CAKE queue data is unavailable, the UI renders a message to that effect instead of appearing to break.
* The Bakery (dynamic queues) uses less RAM, and is more careful to clean up after itself.
* StormGuard won't try to adjust queues before they exist. The Bakery also won't try and remove queues that don't exist yet.
* Fixed the syntax on the "live speed change for APs" call.
