### PR TITLE
changed name trim function

### DIFF
--- a/src/rust/lqosd/src/node_manager/ws/ticker/ipstats_conversion.rs
+++ b/src/rust/lqosd/src/node_manager/ws/ticker/ipstats_conversion.rs
@@ -37,10 +37,11 @@ impl From<&IpStats> for IpStatsWithPlan {
                 .iter()
                 .find(|sd| sd.circuit_id == result.circuit_id)
             {
-                let name = if circuit.circuit_name.len() > 20 {
-                    &circuit.circuit_name[0..20]
+                let name = if circuit.circuit_name.chars().count() > 20 {
+                    let name_trimmed: String = circuit.circuit_name.chars().take(20).collect();
+                    name_trimmed
                 } else {
-                    &circuit.circuit_name
+                    circuit.circuit_name.clone()
                 };
                 result.ip_address = format!("{}", name);
                 result.plan = DownUpOrder { down: circuit.download_max_mbps as f32, up: circuit.upload_max_mbps as f32 };


### PR DESCRIPTION
Fix for issue #747 
The core problem is splitting a UTF-8 string at an invalid byte boundary. For example split in 'č', 'ř', etc.