### PR TITLE
Stormguard tweaks

### DIFF
--- a/src/rust/lqos_config/src/etc/mod.rs
+++ b/src/rust/lqos_config/src/etc/mod.rs
@@ -18,7 +18,7 @@ mod python_migration;
 #[cfg(test)]
 pub mod test_data;
 mod v15;
-pub use v15::{BridgeConfig, Tunables, SingleInterfaceConfig, LazyQueueMode};
+pub use v15::{BridgeConfig, Tunables, SingleInterfaceConfig, LazyQueueMode, StormguardConfig};
 
 static CONFIG: Lazy<ArcSwap<Option<Arc<Config>>>> = Lazy::new(|| ArcSwap::from_pointee(None));
 static INIT_ONCE: Once = Once::new();

--- a/src/rust/lqos_config/src/etc/v15/mod.rs
+++ b/src/rust/lqos_config/src/etc/v15/mod.rs
@@ -22,3 +22,4 @@ pub use bridge::*;
 pub use long_term_stats::LongTermStats;
 pub use tuning::Tunables;
 pub use queues::LazyQueueMode;
+pub use stormguard::StormguardConfig;

--- a/src/rust/lqos_config/src/lib.rs
+++ b/src/rust/lqos_config/src/lib.rs
@@ -15,7 +15,7 @@ mod shaped_devices;
 pub use authentication::{UserRole, WebUser, WebUsers};
 pub use etc::{
     BridgeConfig, Config, Tunables, disable_xdp_bridge, enable_long_term_stats, load_config,
-    update_config, LazyQueueMode, SingleInterfaceConfig
+    update_config, LazyQueueMode, SingleInterfaceConfig, StormguardConfig
 };
 pub use network_json::{NetworkJson, NetworkJsonNode, NetworkJsonTransport};
 pub use program_control::load_libreqos;

--- a/src/rust/lqos_queue_tracker/src/lib.rs
+++ b/src/rust/lqos_queue_tracker/src/lib.rs
@@ -19,7 +19,7 @@ const NUM_QUEUE_HISTORY: usize = 600;
 
 pub use bus::get_raw_circuit_data;
 pub use interval::set_queue_refresh_interval;
-pub use queue_structure::{spawn_queue_structure_monitor, QUEUE_STRUCTURE};
+pub use queue_structure::{spawn_queue_structure_monitor, QUEUE_STRUCTURE, QUEUE_STRUCTURE_CHANGED_STORMGUARD};
 pub use queue_types::deserialize_tc_tree; // Exported for the benchmarker
 pub use tracking::spawn_queue_monitor;
 pub use tracking::{ALL_QUEUE_SUMMARY, TOTAL_QUEUE_STATS};

--- a/src/rust/lqos_queue_tracker/src/queue_structure/mod.rs
+++ b/src/rust/lqos_queue_tracker/src/queue_structure/mod.rs
@@ -1,7 +1,7 @@
 mod queing_structure_json_monitor;
 mod queue_network;
 mod queue_node;
-pub use queing_structure_json_monitor::QUEUE_STRUCTURE;
+pub use queing_structure_json_monitor::{QUEUE_STRUCTURE, QUEUE_STRUCTURE_CHANGED_STORMGUARD};
 pub use queing_structure_json_monitor::spawn_queue_structure_monitor;
 use queue_network::QueueNetwork;
 pub(crate) use queue_node::QueueNode;

--- a/src/rust/lqos_stormguard/src/config.rs
+++ b/src/rust/lqos_stormguard/src/config.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use allocative::Allocative;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 use lqos_bus::TcHandle;
 use crate::queue_structure::{find_queue_bandwidth, find_queue_dependents};
 use crate::STORMGUARD_STATS;
 
-#[derive(Allocative)]
+#[derive(Allocative, Clone)]
 pub struct WatchingSite {
     pub name: String,
     pub max_download_mbps: u64,
@@ -15,7 +15,7 @@ pub struct WatchingSite {
     pub dependent_nodes: Vec<WatchingSiteDependency>,
 }
 
-#[derive(Allocative)]
+#[derive(Allocative, Clone)]
 pub struct WatchingSiteDependency {
     pub name: String,
     pub class_id: TcHandle,
@@ -23,13 +23,37 @@ pub struct WatchingSiteDependency {
     pub original_max_upload_mbps: u64,
 }
 
-#[derive(Allocative)]
 pub struct StormguardConfig {
     pub sites: HashMap<String, WatchingSite>,
     pub download_interface: String,
     pub upload_interface: String,
     pub dry_run: bool,
     pub log_filename: Option<String>,
+}
+
+impl StormguardConfig {
+    pub fn is_empty(&self) -> bool {
+        self.sites.is_empty()
+    }
+
+    pub fn refresh_sites(&mut self) {
+        let Ok(config) = lqos_config::load_config() else {
+            debug!("Unable to reload configuration to refresh StormGuard sites.");
+            return;
+        };
+        let Some(sg_config) = &config.stormguard else {
+            debug!("StormGuard is not enabled in the configuration.");
+            return;
+        };
+
+        // Clear existing stats
+        {
+            let mut lock = STORMGUARD_STATS.lock();
+            lock.clear();
+        }
+        let new_sites = get_sites_from_queueing_structure(sg_config);
+        self.sites = new_sites;
+    }
 }
 
 pub fn configure() -> anyhow::Result<StormguardConfig> {
@@ -50,14 +74,30 @@ pub fn configure() -> anyhow::Result<StormguardConfig> {
         return Err(anyhow::anyhow!("StormGuard is not enabled in the configuration."));
     }
 
+    let sites = get_sites_from_queueing_structure(&sg_config);
+
+    let result = StormguardConfig {
+        sites,
+        download_interface: config.isp_interface().clone(),
+        upload_interface: config.internet_interface().clone(),
+        dry_run: sg_config.dry_run,
+        log_filename: sg_config.log_file.clone(),
+    };
+
+    Ok(result)
+}
+
+fn get_sites_from_queueing_structure(sg_config: &lqos_config::StormguardConfig) -> HashMap<String, WatchingSite> {
     let mut sites = HashMap::new();
     for target in &sg_config.targets {
-        let (max_down, max_up) = find_queue_bandwidth(&target).inspect_err(|e| {
-            error!("Error finding queue bandwidth for {}: {:?}", target, e);
-        })?;
-        let dependencies = find_queue_dependents(&target).inspect_err(|e| {
-            error!("Error finding queue dependencies for {}: {:?}", target, e);
-        })?;
+        let Ok((max_down, max_up)) = find_queue_bandwidth(&target) else {
+            debug!("Error finding queue bandwidth for {}", target);
+            continue;
+        };
+        let Ok(dependencies) = find_queue_dependents(&target) else {
+            debug!("Error finding queue dependencies for {}", target);
+            continue;
+        };
         let min_down = (max_down as f32 * sg_config.minimum_download_percentage) as u64;
         let min_up = (max_up as f32 * sg_config.minimum_upload_percentage) as u64;
         let site = WatchingSite {
@@ -74,14 +114,5 @@ pub fn configure() -> anyhow::Result<StormguardConfig> {
             lock.push((target.to_owned(), max_down, max_up));
         }
     }
-
-    let result = StormguardConfig {
-        sites,
-        download_interface: config.isp_interface().clone(),
-        upload_interface: config.internet_interface().clone(),
-        dry_run: sg_config.dry_run,
-        log_filename: sg_config.log_file.clone(),
-    };
-
-    Ok(result)
-}
+    sites
+    }

--- a/src/rust/lqos_stormguard/src/config.rs
+++ b/src/rust/lqos_stormguard/src/config.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use allocative::Allocative;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 use lqos_bus::TcHandle;
 use crate::queue_structure::{find_queue_bandwidth, find_queue_dependents};
 use crate::STORMGUARD_STATS;
@@ -37,16 +37,16 @@ pub fn configure() -> anyhow::Result<StormguardConfig> {
     let config = lqos_config::load_config()?;
 
     if config.on_a_stick_mode() {
-        error!("LibreQoS StormGuard is not supported in 'on-a-stick' mode.");
+        info!("LibreQoS StormGuard is not supported in 'on-a-stick' mode.");
         return Err(anyhow::anyhow!("LibreQoS StormGuard is not supported in 'on-a-stick' mode."));
     }
 
     let Some(sg_config) = &config.stormguard else {
-        error!("StormGuard is not enabled in the configuration.");
+        debug!("StormGuard is not enabled in the configuration.");
         return Err(anyhow::anyhow!("StormGuard is not enabled in the configuration."));
     };
     if !sg_config.enabled {
-        error!("StormGuard is not enabled in the configuration.");
+        debug!("StormGuard is not enabled in the configuration.");
         return Err(anyhow::anyhow!("StormGuard is not enabled in the configuration."));
     }
 

--- a/src/rust/lqos_stormguard/src/site_state.rs
+++ b/src/rust/lqos_stormguard/src/site_state.rs
@@ -18,18 +18,18 @@ use crate::site_state::ring_buffer::RingBuffer;
 use crate::site_state::site::SiteState;
 use crate::site_state::stormguard_state::StormguardState;
 
-pub struct SiteStateTracker<'a> {
-    sites: HashMap<String, SiteState<'a>>,
+pub struct SiteStateTracker {
+    sites: HashMap<String, SiteState>,
 }
 
-impl<'a> SiteStateTracker<'a> {
-    pub fn from_config(config: &'a StormguardConfig) -> Self {
+impl SiteStateTracker {
+    pub fn from_config(config: &StormguardConfig) -> Self {
         let mut sites = HashMap::new();
         for (name, site) in &config.sites {
             sites.insert(
                 name.clone(),
                 SiteState {
-                    config: site,
+                    config: site.clone(),
                     download_state: StormguardState::Warmup,
                     upload_state: StormguardState::Warmup,
                     throughput_down: RingBuffer::new(READING_ACCUMULATOR_SIZE),

--- a/src/rust/lqos_stormguard/src/site_state/site.rs
+++ b/src/rust/lqos_stormguard/src/site_state/site.rs
@@ -6,8 +6,8 @@ use crate::site_state::recommendation::{Recommendation, RecommendationAction, Re
 use crate::site_state::ring_buffer::RingBuffer;
 use crate::site_state::stormguard_state::StormguardState;
 
-pub struct SiteState<'a> {
-    pub config: &'a WatchingSite,
+pub struct SiteState {
+    pub config: WatchingSite,
     pub download_state: StormguardState,
     pub upload_state: StormguardState,
 
@@ -53,7 +53,7 @@ impl RecommendationParams {
     }
 }
 
-impl<'a> SiteState<'a> {
+impl SiteState {
     pub fn check_state(&mut self) {
         match self.download_state {
             StormguardState::Warmup => {

--- a/src/rust/lqosd/src/node_manager/static2/config_stormguard.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_stormguard.html
@@ -1,6 +1,14 @@
 <div id="configMenuContainer"></div>
 <div class="row">
     <div class="col-12">
+        <!-- Warning Message -->
+        <div class="alert alert-warning d-flex align-items-center mb-4" role="alert">
+            <i class="fa fa-exclamation-triangle me-2"></i>
+            <div>
+                <strong>Advanced Feature:</strong> StormGuard is designed to mitigate highly unstable network links, such as those found in maritime environments. Please only enable this feature if you are experiencing significant network instability that requires automatic rate adjustments.
+            </div>
+        </div>
+        
         <form>
             <!-- Enable/Disable StormGuard -->
             <div class="mb-3 form-check">


### PR DESCRIPTION
Stormguard improvements:

* Doesn't warn if you aren't using it.
* Has a warning in the config.
* Doesn't stop on startup if queues aren't around.
* Reloads its state when queueingStructure.json changes, flushing previous state.