### PR TITLE
Fix UISP IP import to preserve legitimate subnet assignments

### DIFF
--- a/src/rust/uisp_integration/src/uisp_types/uisp_device.rs
+++ b/src/rust/uisp_integration/src/uisp_types/uisp_device.rs
@@ -1,7 +1,7 @@
 use crate::ip_ranges::IpRanges;
 use lqos_config::Config;
 use std::collections::HashSet;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use uisp::Device;
 
 #[derive(Debug)]
@@ -23,6 +23,47 @@ pub struct UispDevice {
 }
 
 impl UispDevice {
+    /// Check if an IP/CIDR represents a network address (all host bits are zero)
+    /// Returns true if it's a network address, false if it's a host address
+    #[cfg_attr(test, allow(dead_code))]
+    pub fn is_network_address(cidr: &str) -> bool {
+        if !cidr.contains('/') {
+            return false;
+        }
+        
+        let parts: Vec<&str> = cidr.split('/').collect();
+        if parts.len() != 2 {
+            return false;
+        }
+        
+        let ip_str = parts[0];
+        let prefix_len: u32 = match parts[1].parse() {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+        
+        // Parse the IP address
+        let ip: Ipv4Addr = match ip_str.parse() {
+            Ok(addr) => addr,
+            Err(_) => return false,
+        };
+        
+        // Convert IP to u32 for bit manipulation
+        let ip_bits = u32::from(ip);
+        
+        // Calculate the host mask (bits that should be zero for a network address)
+        let host_bits = 32 - prefix_len;
+        if host_bits == 0 {
+            // /32 is always treated as a host address
+            return false;
+        }
+        
+        let host_mask = (1u32 << host_bits) - 1;
+        
+        // Check if all host bits are zero
+        (ip_bits & host_mask) == 0
+    }
+
     /// Creates a new UispDevice from a UISP device
     ///
     /// # Arguments
@@ -68,7 +109,28 @@ impl UispDevice {
             upload = config.queues.generated_pn_upload_mbps;
         }
 
-        // Accumulate IP address listings
+        // Process the single ipAddress field (never includes CIDR, always /32)
+        if let Some(ip) = &device.ipAddress {
+            if ip.contains(':') {
+                // It's IPv6
+                ipv6.insert(ip.clone());
+            } else {
+                // It's IPv4 - always add as /32
+                let base_ip = if ip.contains('/') {
+                    ip.split('/').next().unwrap_or(ip)
+                } else {
+                    ip.as_str()
+                };
+                ipv4.insert(format!("{}/32", base_ip));
+                
+                // Check for a Mikrotik Mapping
+                if let Some(mapping) = ipv4_to_v6.iter().find(|m| m.ipv4 == base_ip) {
+                    ipv6.insert(mapping.ipv6.clone());
+                }
+            }
+        }
+
+        // Accumulate IP address listings from interfaces
         if let Some(interfaces) = &device.interfaces {
             for interface in interfaces.iter() {
                 if let Some(addr) = &interface.addresses {
@@ -79,14 +141,24 @@ impl UispDevice {
                                 ipv6.insert(address.clone());
                             } else {
                                 // It's IPv4
-                                // We can't trust UISP to provide the correct suffix, so change that to /32
+                                // Check if this is a network address or host address
                                 if address.contains('/') {
                                     let splits: Vec<_> = address.split('/').collect();
-                                    ipv4.insert(format!("{}/32", splits[0]));
+                                    let base_ip = splits[0];
+                                    
+                                    // If it's a network address (e.g., 5.5.6.0/24), keep the CIDR
+                                    // If it's a host address (e.g., 5.5.6.1/24), make it /32
+                                    let final_address = if Self::is_network_address(address) {
+                                        address.clone()
+                                    } else {
+                                        format!("{}/32", base_ip)
+                                    };
+                                    
+                                    ipv4.insert(final_address);
 
                                     // Check for a Mikrotik Mapping
                                     if let Some(mapping) =
-                                        ipv4_to_v6.iter().find(|m| m.ipv4 == splits[0])
+                                        ipv4_to_v6.iter().find(|m| m.ipv4 == base_ip)
                                     {
                                         ipv6.insert(mapping.ipv6.clone());
                                     }
@@ -108,33 +180,26 @@ impl UispDevice {
         }
 
         // Also process ipAddressList if available (for blackbox devices with multiple IPs)
+        // These never include CIDR naturally, always treat as /32
         if let Some(ip_list) = &device.ipAddressList {
             for address in ip_list.iter() {
                 if address.contains(':') {
                     // It's IPv6
                     ipv6.insert(address.clone());
                 } else {
-                    // It's IPv4
-                    // We need to use /32 for consistency with the filtering logic
-                    if address.contains('/') {
-                        let splits: Vec<_> = address.split('/').collect();
-                        ipv4.insert(format!("{}/32", splits[0]));
-
-                        // Check for a Mikrotik Mapping
-                        if let Some(mapping) =
-                            ipv4_to_v6.iter().find(|m| m.ipv4 == splits[0])
-                        {
-                            ipv6.insert(mapping.ipv6.clone());
-                        }
+                    // It's IPv4 - always add as /32
+                    let base_ip = if address.contains('/') {
+                        address.split('/').next().unwrap_or(address)
                     } else {
-                        ipv4.insert(format!("{address}/32"));
+                        address.as_str()
+                    };
+                    ipv4.insert(format!("{}/32", base_ip));
 
-                        // Check for a Mikrotik Mapping
-                        if let Some(mapping) =
-                            ipv4_to_v6.iter().find(|m| m.ipv4 == address.as_str())
-                        {
-                            ipv6.insert(mapping.ipv6.clone());
-                        }
+                    // Check for a Mikrotik Mapping
+                    if let Some(mapping) =
+                        ipv4_to_v6.iter().find(|m| m.ipv4 == base_ip)
+                    {
+                        ipv6.insert(mapping.ipv6.clone());
                     }
                 }
             }
@@ -215,5 +280,40 @@ impl UispDevice {
         result.truncate(result.len() - 2);
         let result = format!("[{result}]");
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UispDevice;
+
+    #[test]
+    fn test_is_network_address() {
+        // Network addresses (should return true)
+        assert!(UispDevice::is_network_address("192.168.1.0/24"));
+        assert!(UispDevice::is_network_address("10.0.0.0/8"));
+        assert!(UispDevice::is_network_address("172.16.0.0/16"));
+        assert!(UispDevice::is_network_address("23.148.208.224/29")); // 224 = 11100000, network for /29
+        assert!(UispDevice::is_network_address("5.5.6.0/24"));
+        assert!(UispDevice::is_network_address("192.168.0.0/23"));
+        assert!(UispDevice::is_network_address("10.10.10.128/25")); // 128 = 10000000, network for /25
+        
+        // Host addresses (should return false)
+        assert!(!UispDevice::is_network_address("192.168.1.1/24"));
+        assert!(!UispDevice::is_network_address("192.168.1.255/24"));
+        assert!(!UispDevice::is_network_address("10.0.0.1/8"));
+        assert!(!UispDevice::is_network_address("172.16.0.1/16"));
+        assert!(!UispDevice::is_network_address("23.148.208.225/29")); // 225 = 11100001, host in /29
+        assert!(!UispDevice::is_network_address("5.5.6.1/24"));
+        assert!(!UispDevice::is_network_address("192.168.0.1/23"));
+        assert!(!UispDevice::is_network_address("10.10.10.129/25")); // 129 = 10000001, host in /25
+        
+        // Special cases
+        assert!(!UispDevice::is_network_address("192.168.1.1/32")); // /32 is always a host
+        assert!(!UispDevice::is_network_address("192.168.1.0/32")); // /32 is always a host
+        assert!(!UispDevice::is_network_address("192.168.1.1")); // No CIDR
+        assert!(!UispDevice::is_network_address("")); // Empty string
+        assert!(!UispDevice::is_network_address("not-an-ip/24")); // Invalid IP
+        assert!(!UispDevice::is_network_address("192.168.1.0/invalid")); // Invalid prefix
     }
 }


### PR DESCRIPTION
Problem

Previously, all IPv4 addresses from UISP were forced to /32, even when
legitimate subnet assignments (like /29 or /24) were configured for client
 sites. This prevented proper shaping of entire assigned subnets.

Solution

Implement better CIDR handling based on the source of the IP address:

IP Sources & Handling:
- device.ipAddress → Always /32 (field never includes CIDR)
- device.ipAddressList → Always /32 (field never includes CIDR)
- device.interfaces.addresses.cidr → Smart detection:
  - Network addresses (e.g., 23.148.208.224/29, 5.5.6.0/24) → Keep
original CIDR
  - Host addresses (e.g., 5.5.6.1/24, 192.168.1.100/24) → Convert to /32

Technical Details

- Added is_network_address() function that checks if all host bits are
zero
- Preserves legitimate subnet assignments while preventing over-shaping of
 individual hosts
- Includes comprehensive test coverage for various CIDR scenarios

Testing

✅ All tests passing
✅ Correctly identifies network vs host addresses
✅ Handles edge cases (/32, invalid inputs, etc.)

Fixes customer-reported issue where subnet assignments like /29 were being
 incorrectly reduced to /32.