### PR TITLE
Fix Links For Tree Nodes At Capacity Widget

### DIFF
--- a/src/rust/lqosd/src/node_manager/js_build/src/dashlets/tree_capacity_dash.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/dashlets/tree_capacity_dash.js
@@ -68,7 +68,7 @@ export class TreeCapacityDash extends DashletBaseInsight {
 
                 let linkCol = document.createElement("td");
                 let link = document.createElement("a");
-                link.href = "/node.html?id=" + node.id;
+                link.href = "/tree.html?id=" + node.id;
                 link.innerText = node.name;
                 link.classList.add("tiny", "redactable");
                 linkCol.appendChild(link);


### PR DESCRIPTION
Fix Issue:

- Tree Nodes At Capacity Widget - if a user clicks one of its links, it directs to node.hmtl instead of tree.html (causing page not found)