### PR TITLE
Add Multiple Topology Strategies for Splynx Integration

### DIFF
--- a/docs-es/v2.0/integrations-es.md
+++ b/docs-es/v2.0/integrations-es.md
@@ -12,7 +12,33 @@
 
 ## Integración con Splynx
 
+> **⚠️ Aviso de Cambio Importante**: Antes de v1.5-RC-2, la estrategia predeterminada de Splynx era `full`. A partir de v1.5-RC-2, la estrategia predeterminada es `ap_only` para un mejor rendimiento del CPU. Si requiere el comportamiento anterior, configure explícitamente `strategy = "full"` en su sección de configuración de Splynx.
+
 Primero, configure los parámetros relevantes de Splynx (splynx_api_key, splynx_api_secret, etc.) en `/etc/lqos.conf`.
+
+### Estrategias de Topología
+
+LibreQoS soporta múltiples estrategias de topología para la integración con Splynx, balanceando el rendimiento del CPU con las necesidades de jerarquía de red:
+
+| Estrategia | Descripción | Impacto CPU | Caso de Uso |
+|------------|-------------|-------------|-------------|
+| `flat` | Solo regula suscriptores, sin jerarquía | Menor | Máximo rendimiento, regulación simple de suscriptores únicamente |
+| `ap_only` | Una capa: AP → Clientes | Bajo | **Predeterminado**. Mejor balance entre rendimiento y estructura |
+| `ap_site` | Dos capas: Sitio → AP → Clientes | Medio | Agregación a nivel de sitio con complejidad moderada |
+| `full` | Mapeo completo de topología | Mayor | Representación completa de jerarquía de red |
+
+Configure la estrategia en `/etc/lqos.conf` bajo la sección `[splynx]`:
+
+```ini
+[splynx]
+# ... otras configuraciones de splynx ...
+strategy = "ap_only"
+```
+
+**Consideraciones de Rendimiento:**
+- Las estrategias `flat` y `ap_only` reducen significativamente la carga del CPU al limitar la profundidad de la red
+- Elija `ap_only` para la mayoría de implementaciones a menos que necesite agregación de tráfico a nivel de sitio
+- Use `full` solamente si requiere representación completa de la topología de red y tiene recursos CPU adecuados
 
 ### Acceso API de Splynx
 

--- a/docs/v2.0/integrations.md
+++ b/docs/v2.0/integrations.md
@@ -12,7 +12,33 @@
 
 ## Splynx Integration
 
+> **⚠️ Breaking Change Notice**: Prior to v1.5-RC-2, the default Splynx strategy was `full`. Starting with v1.5-RC-2, the default strategy is `ap_only` for improved CPU performance. If you require the previous behavior, explicitly set `strategy = "full"` in your Splynx configuration section.
+
 First, set the relevant parameters for Splynx (splynx_api_key, splynx_api_secret, etc.) in `/etc/lqos.conf`.
+
+### Topology Strategies
+
+LibreQoS supports multiple topology strategies for Splynx integration to balance CPU performance with network hierarchy needs:
+
+| Strategy | Description | CPU Impact | Use Case |
+|----------|-------------|------------|----------|
+| `flat` | Only shapes subscribers, no hierarchy | Lowest | Maximum performance, simple subscriber-only shaping |
+| `ap_only` | Single layer: AP → Clients | Low | **Default**. Best balance of performance and structure |
+| `ap_site` | Two layers: Site → AP → Clients | Medium | Site-level aggregation with moderate complexity |
+| `full` | Complete topology mapping | Highest | Full network hierarchy representation |
+
+Configure the strategy in `/etc/lqos.conf` under the `[splynx]` section:
+
+```ini
+[splynx]
+# ... other splynx settings ...
+strategy = "ap_only"
+```
+
+**Performance Considerations:**
+- `flat` and `ap_only` strategies significantly reduce CPU load by limiting network depth
+- Choose `ap_only` for most deployments unless you need site-level traffic aggregation
+- Only use `full` if you require complete network topology representation and have adequate CPU resources
 
 ### Splynx API Access
 

--- a/src/rust/lqos_config/src/etc/v15/spylnx_integration.rs
+++ b/src/rust/lqos_config/src/etc/v15/spylnx_integration.rs
@@ -7,6 +7,12 @@ pub struct SplynxIntegration {
     pub api_key: String,
     pub api_secret: String,
     pub url: String,
+    #[serde(default = "default_strategy")]
+    pub strategy: String,
+}
+
+fn default_strategy() -> String {
+    "ap_only".to_string()
 }
 
 impl Default for SplynxIntegration {
@@ -16,6 +22,7 @@ impl Default for SplynxIntegration {
             api_key: "".to_string(),
             api_secret: "".to_string(),
             url: "".to_string(),
+            strategy: "ap_only".to_string(),
         }
     }
 }

--- a/src/rust/lqos_python/src/lib.rs
+++ b/src/rust/lqos_python/src/lib.rs
@@ -70,6 +70,7 @@ fn liblqos_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(splynx_api_key, m)?)?;
     m.add_function(wrap_pyfunction!(splynx_api_secret, m)?)?;
     m.add_function(wrap_pyfunction!(splynx_api_url, m)?)?;
+    m.add_function(wrap_pyfunction!(splynx_strategy, m)?)?;
     m.add_function(wrap_pyfunction!(automatic_import_uisp, m)?)?;
     m.add_function(wrap_pyfunction!(automatic_import_splynx, m)?)?;
     m.add_function(wrap_pyfunction!(queue_refresh_interval_mins, m)?)?;
@@ -561,6 +562,15 @@ fn splynx_api_url() -> PyResult<String> {
     let config = lqos_config::load_config().unwrap();
     let url = config.spylnx_integration.url.clone();
     Ok(url)
+}
+
+#[pyfunction]
+fn splynx_strategy() -> PyResult<String> {
+    let config = lqos_config::load_config();
+    match config {
+        Ok(config) => Ok(config.spylnx_integration.strategy.clone()),
+        Err(_) => Ok("ap_only".to_string()), // Default value when config can't be loaded
+    }
 }
 
 #[pyfunction]


### PR DESCRIPTION
## Summary

Adds configurable topology strategies to the Splynx integration to address
CPU congestion issues caused by deeply nested network structures. The
default behavior changes to ap_only mode for better CPU distribution.

⚠️ Breaking Change

Default behavior has changed. The Splynx integration now defaults to
ap_only strategy instead of the previous full topology mapping.

Action Required: If you want to maintain the current shaping behavior, add
this to your /etc/lqos.conf:

```
[spylnx_integration]
strategy = "full"
```

## New Features

Four Topology Strategies Available:

1. flat - Only shapes subscribers, ignoring parent node relationships
  - Creates completely flat structure with just individual client entries
  - Minimal CPU congestion, maximum distribution
2. ap_only ⭐ [NEW DEFAULT] - Single layer of AP + clients
  - Similar to default Preseem behavior
  - Good for huge networks needing wide CPU spread
  - Only creates AP nodes, clients connect directly
3. ap_site - Site > AP > clients structure
  - Site level is top-most parent
  - Two-level hierarchy for better organization
  - Also good for large networks with better structure than ap_only
4. full - Complete topology mapping
  - This was the previous default behavior
  - Provides full mapping: sites > backhauls > APs > clients
  - Most detailed but can cause CPU congestion on large networks

## Configuration

Add to /etc/lqos.conf under [spylnx_integration] section:
[spylnx_integration]
strategy = "ap_only"  # or "flat", "ap_site", "full"

## Backward Compatibility

- Works without the strategy field (defaults to ap_only)
- All existing bandwidth limits, IP addresses, and subscriber properties
are preserved
- No API changes to other integrations

## Technical Implementation

- Added strategy field to Splynx configuration with serde default
- Implemented proper error handling for missing config files
- Refactored existing logic into strategy-specific functions
- Added configuration validation and routing

## Migration Guide

- No action needed for basic functionality (will use ap_only mode)
- To keep current behavior: Add strategy = "full" to config
- For better performance on large networks: Try ap_only (default) or flat
- For organized large networks: Use ap_site

## Files Changed

- rust/lqos_config/src/etc/v15/spylnx_integration.rs - Added strategy
config field
- rust/lqos_python/src/lib.rs - Added Python binding with error handling
- integrationSplynx.py - Implemented multiple topology strategies
