### PR TITLE
Implement `promote_to_root` for the UISP integration

### DIFF
--- a/docs-es/v2.0/integrations-es.md
+++ b/docs-es/v2.0/integrations-es.md
@@ -40,6 +40,32 @@ strategy = "ap_only"
 - Elija `ap_only` para la mayoría de implementaciones a menos que necesite agregación de tráfico a nivel de sitio
 - Use `full` solamente si requiere representación completa de la topología de red y tiene recursos CPU adecuados
 
+### Promover Nodos a Raíz (Optimización de Rendimiento)
+
+Cuando use la estrategia de topología `full`, puede encontrar cuellos de botella de rendimiento del CPU donde todo el tráfico fluye a través de un solo sitio raíz, limitando el throughput a lo que un solo núcleo de CPU puede manejar.
+
+La función **promote_to_root** soluciona esto promoviendo sitios específicos a nodos de nivel raíz, distribuyendo la regulación de tráfico entre múltiples núcleos de CPU.
+
+**Configuración:**
+1. Navegue a Integración → Común en la interfaz web
+2. En el campo "Promover Nodos a Raíz", ingrese un nombre de sitio por línea:
+```
+Sitio_Remoto_Alpha
+Sitio_Remoto_Beta
+Centro_Datos_Oeste
+```
+
+**Beneficios:**
+- Elimina el cuello de botella de CPU único para redes con sitios remotos
+- Distribuye la regulación de tráfico entre múltiples núcleos de CPU
+- Mejora el rendimiento general de la red para topologías grandes
+- Funciona tanto con integraciones de Splynx como de UISP
+
+**Cuándo Usar:**
+- Redes con múltiples sitios remotos de alta capacidad
+- Cuando use la estrategia de topología `full` y experimente limitaciones de CPU
+- Redes grandes donde el tráfico del sitio raíz excede la capacidad de un solo núcleo
+
 ### Acceso API de Splynx
 
 La integración con Splynx utiliza autenticación Básica. Para usar este tipo de autenticación, asegúrese de habilitar el [Acceso No Seguro](https://splynx.docs.apiary.io/#introduction/authentication) en la configuración de su clave API de Splynx. Además, la clave API de Splynx debe tener los permisos adecuados.
@@ -113,6 +139,8 @@ LibreQoS soporta múltiples estrategias de topología para la integración con U
 - Use `ap_site` si necesita control a nivel de sitio pero no necesita regulación de backhaul
 - Use `ap_only` para mejor rendimiento cuando no se necesita agregación de sitios
 - Use `flat` solo cuando el máximo rendimiento es crítico y no necesita ninguna jerarquía
+
+**Nota de Rendimiento:** Cuando use la estrategia `full` con redes grandes, considere usar la función **promote_to_root** (vea [Promover Nodos a Raíz](#promover-nodos-a-raíz-optimización-de-rendimiento) arriba) para distribuir la carga del CPU entre múltiples núcleos.
 
 ### Estrategias de Manejo de Suspensiones
 

--- a/docs/v2.0/integrations.md
+++ b/docs/v2.0/integrations.md
@@ -40,6 +40,32 @@ strategy = "ap_only"
 - Choose `ap_only` for most deployments unless you need site-level traffic aggregation
 - Only use `full` if you require complete network topology representation and have adequate CPU resources
 
+### Promote to Root Nodes (Performance Optimization)
+
+When using `full` topology strategy, you may encounter CPU performance bottlenecks where all traffic flows through a single root site, limiting throughput to what one CPU core can handle.
+
+The **promote_to_root** feature solves this by promoting specific sites to root-level nodes, distributing traffic shaping across multiple CPU cores.
+
+**Configuration:**
+1. Navigate to Integration → Common in the WebUI
+2. In the "Promote to Root Nodes" field, enter one site name per line:
+```
+Remote_Site_Alpha
+Remote_Site_Beta
+Datacenter_West
+```
+
+**Benefits:**
+- Eliminates single-CPU bottleneck for networks with remote sites
+- Distributes traffic shaping across multiple CPU cores
+- Improves overall network performance for large topologies
+- Works with both Splynx and UISP integrations
+
+**When to Use:**
+- Networks with multiple high-capacity remote sites
+- When using `full` topology strategy and experiencing CPU limitations
+- Large networks where root site traffic exceeds single-core capacity
+
 ### Splynx API Access
 
 The Splynx Integration uses Basic authentication. For using this type of authentication, please make sure you enable [Unsecure access](https://splynx.docs.apiary.io/#introduction/authentication) in your Splynx API key settings. Also the Splynx API key should be granted access to the necessary permissions.
@@ -114,6 +140,8 @@ LibreQoS supports multiple topology strategies for UISP integration to balance C
 - Use `ap_site` if you need site-level control but don't need backhaul shaping
 - Use `ap_only` for better performance when site aggregation isn't needed
 - Use `flat` only when maximum performance is critical and you don't need any hierarchy
+
+**Performance Note:** When using `full` strategy with large networks, consider using the **promote_to_root** feature (see [Promote to Root Nodes](#promote-to-root-nodes-performance-optimization) above) to distribute CPU load across multiple cores.
 
 ### Suspension Handling Strategies
 


### PR DESCRIPTION
Summary

• Add promote_to_root support to UISP Integration to eliminate single-CPU bottleneck
• Fix Integration Common UI text to correctly describe node names vs circuit IDs
• Enable multi-root network topology for improved performance in UISP "full" modes

Changes Made

UISP Integration Enhancement:
- Modified /src/rust/uisp_integration/src/strategies/full2.rs to support promote_to_root functionality
- Added logic to process integration_common.promote_to_root configuration
- Enhanced network.json generation to include promoted nodes as top-level entries
- Preserves existing routing calculations while distributing traffic shaping across multiple CPU cores

UI Fix:
- Updated /src/bin/static2/config_integration.html help text from "circuit ID" to "node name" for accuracy

Technical Implementation

- Uses existing Integration Common configuration (no new settings required)
- Processes promote_to_root list into HashSet for efficient lookups
- Modifies network.json filtering to include both root children AND promoted nodes
- Maintains backward compatibility with existing configurations

Benefits

- Performance: Eliminates single-CPU bottleneck when using UISP full strategy
- Consistency: Same promote_to_root behavior across all integrations (Splynx, UISP)
- User-friendly: Single configuration point for all integration types
- Minimal impact: ~15 lines of code change with no breaking changes