### PR TITLE
Fix Clearing Unknown IPs #485 Add “Clear Unknown IPs” endpoint and UI button

### DIFF
--- a/src/rust/lqosd/src/node_manager/js_build/src/unknown-ips.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/unknown-ips.js
@@ -6,8 +6,32 @@ button.onclick = () => {
    window.location.href = "/local-api/unknownIpsCsv";
 };
 
+let clearButton = document.getElementById("btnClear");
+if (clearButton) {
+   clearButton.onclick = async () => {
+      try {
+         await fetch("/local-api/unknownIps/clear", { method: "POST" });
+      } catch (e) {
+         console.error("Failed to clear unknown IPs", e);
+      } finally {
+         // Reload to refresh the list
+         window.location.reload();
+      }
+   };
+}
+
 $.get("/local-api/unknownIps", (data) => {
    let target = document.getElementById("unknown");
+   clearDiv(target);
+
+   if (!data || data.length === 0) {
+      const p = document.createElement('p');
+      p.classList.add('text-muted');
+      p.textContent = 'No unknown IPs seen in the last 5 minutes.';
+      target.appendChild(p);
+      return;
+   }
+
    let table = document.createElement("table");
    table.classList.add("table", "table-striped");
    let thead = document.createElement("thead");
@@ -27,8 +51,5 @@ $.get("/local-api/unknownIps", (data) => {
    });
 
    table.appendChild(tbody);
-   clearDiv(target);
    target.appendChild(table);
-
-   //console.log(data);
 });

--- a/src/rust/lqosd/src/node_manager/local_api.rs
+++ b/src/rust/lqosd/src/node_manager/local_api.rs
@@ -40,6 +40,7 @@ pub fn local_api(shaper_query: tokio::sync::mpsc::Sender<ShaperQueryCommand>) ->
         .route("/search", post(search::search))
         .route("/unknownIps", get(unknown_ips::unknown_ips))
         .route("/unknownIpsCsv", get(unknown_ips::unknown_ips_csv))
+        .route("/unknownIps/clear", post(unknown_ips::clear_unknown_ips))
         .route("/reloadLqos", get(reload_libreqos::reload_libreqos))
         .route("/adminCheck", get(config::admin_check))
         .route("/getConfig", get(config::get_config))

--- a/src/rust/lqosd/src/node_manager/local_api/unknown_ips.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/unknown_ips.rs
@@ -5,6 +5,7 @@ use lqos_config::load_config;
 use lqos_utils::units::DownUpOrder;
 use lqos_utils::unix_time::time_since_boot;
 use serde::Serialize;
+use std::collections::HashSet;
 use std::time::Duration;
 use tracing::warn;
 
@@ -84,4 +85,74 @@ pub async fn unknown_ips_csv() -> String {
     }
 
     csv
+}
+
+#[derive(Serialize)]
+pub struct ClearUnknownIpsResponse {
+    cleared: usize,
+}
+
+pub async fn clear_unknown_ips() -> axum::Json<ClearUnknownIpsResponse> {
+    // Load config and shaped devices to mirror the same filtering logic used for display
+    let Ok(config) = load_config() else {
+        warn!("Failed to load config");
+        return axum::Json(ClearUnknownIpsResponse { cleared: 0 });
+    };
+    let allowed_ips = config.ip_ranges.allowed_network_table();
+    let ignored_ips = config.ip_ranges.ignored_network_table();
+
+    let sd_reader = SHAPED_DEVICES.load();
+
+    // Now time for last_seen comparison (match the 5 minute window used in get_unknown_ips)
+    let now = match time_since_boot() {
+        Ok(ts) => Duration::from(ts).as_nanos() as u64,
+        Err(_) => 0,
+    };
+    const FIVE_MINUTES_IN_NANOS: u64 = 5 * 60 * 1_000_000_000;
+
+    // Determine the set of keys to remove
+    let to_remove: Vec<lqos_utils::XdpIpAddress> = {
+        let raw = THROUGHPUT_TRACKER.raw_data.lock();
+        raw.iter()
+            // Remove all loopback devices
+            .filter(|(k, _v)| !k.as_ip().is_loopback())
+            // Only those with tc_handle == 0 (unknown/unshaped)
+            .filter(|(_k, d)| d.tc_handle.as_u32() == 0)
+            // Honor ignored list (if enabled)
+            .filter(|(k, _d)| {
+                let ip = k.as_ip();
+                !(config.ip_ranges.unknown_ip_honors_ignore.unwrap_or(true)
+                    && ignored_ips.longest_match(ip).is_some())
+            })
+            // Honor allowed list (if enabled)
+            .filter(|(k, _d)| {
+                let ip = k.as_ip();
+                !(config.ip_ranges.unknown_ip_honors_allow.unwrap_or(true)
+                    && allowed_ips.longest_match(ip).is_none())
+            })
+            // Only those not in shaped devices
+            .filter(|(k, _d)| sd_reader.trie.longest_match(k.as_ip()).is_none())
+            // Only those seen within the last 5 minutes (matches display)
+            .filter(|(_k, d)| now.saturating_sub(d.last_seen) < FIVE_MINUTES_IN_NANOS)
+            .map(|(k, _)| *k)
+            .collect()
+    };
+
+    let to_remove_set: HashSet<_> = to_remove.iter().cloned().collect();
+    let cleared = to_remove_set.len();
+
+    // Hard clear: remove from in-memory tracker and expire from kernel map
+    {
+        let mut raw = THROUGHPUT_TRACKER.raw_data.lock();
+        raw.retain(|k, _| !to_remove_set.contains(k));
+        raw.shrink_to_fit();
+    }
+
+    if cleared > 0 {
+        if let Err(e) = lqos_sys::expire_throughput(to_remove) {
+            warn!("Failed to expire throughput entries during clear: {:?}", e);
+        }
+    }
+
+    axum::Json(ClearUnknownIpsResponse { cleared })
 }

--- a/src/rust/lqosd/src/node_manager/static2/unknown_ips.html
+++ b/src/rust/lqosd/src/node_manager/static2/unknown_ips.html
@@ -2,9 +2,14 @@
     <div class="col-12">
         <h5><i class="fa fa-question"></i> Unrecognized IP Addresses</h5>
         <p>These are the IP addresses that have been seen on the network, but have not been assigned to a device.</p>
-        <button class="btn btn-primary" type="button" id="btnCsv">
-            <i class="fa fa-table"></i> Download as CSV
-        </button>
+        <div class="mb-2">
+            <button class="btn btn-primary" type="button" id="btnCsv">
+                <i class="fa fa-table"></i> Download as CSV
+            </button>
+            <button class="btn btn-outline-danger ms-2" type="button" id="btnClear">
+                <i class="fa fa-trash"></i> Clear Unknowns
+            </button>
+        </div>
         <div id="unknown">
             <i class="fa fa-spinner fa-spin"></i> Loading, Please Wait...
         </div>


### PR DESCRIPTION
Summary

- Adds a one-click way to clear Unknown IPs from the Node Manager.
- Uses hard clear (removes entries and resets counters) to achieve intended
behavior.

Changes

- Backend: POST /local-api/unknownIps/clear in local_api.rs →
unknown_ips::clear_unknown_ips.
- Handler: Mirrors list filters and:
    - Removes matching keys from THROUGHPUT_TRACKER.raw_data.
    - Bulk-deletes corresponding kernel counters via
lqos_sys::expire_throughput.
- UI: Adds “Clear Unknowns” button on unknown_ips.html; JS posts to the new
endpoint and reloads.
- UX: Empty-state message when no unknowns exist in last 5 minutes.

Rationale

- Unknown IPs could persist without an easy manual reset.
- Hard clear ensures a clean slate immediately; entries reappear only if new
traffic occurs.

Safety/Impact

- No effect on shaping or forwarding; changes are limited to counters/
trackers.
- Uses a short-lived lock on the throughput map; worst case slightly delays
stats/UI updates.
- Kernel map clear uses bulk delete (single lock) for efficiency.

Endpoints

- New: POST /local-api/unknownIps/clear → { "cleared": <count> }
- Existing unchanged: GET /local-api/unknownIps, GET /local-api/unknownIpsCsv

Config

- No config changes; honors “Unknown IPs Honor Allow/Ignore List” settings
as before.
- TTL remains 5 minutes.