### PR TITLE
Speed Gauge Improvements for Circuit Page

### DIFF
--- a/src/rust/lqosd/dev_build.sh
+++ b/src/rust/lqosd/dev_build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tiny helper for local UI iteration: builds JS and copies it to bin/static2.
+# Usage: from repo root or from this directory:
+#   bash rust/lqosd/dev_build.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "[dev_build] Building JS bundles..."
+pushd "$SCRIPT_DIR/src/node_manager/js_build" >/dev/null
+./esbuild.sh
+popd >/dev/null
+
+echo "[dev_build] Copying bundles to bin/static2..."
+mkdir -p "$SCRIPT_DIR/../../bin/static2"
+cp -R "$SCRIPT_DIR/src/node_manager/js_build/out/"* "$SCRIPT_DIR/../../bin/static2/"
+
+echo "[dev_build] Done. Hard refresh your browser (Ctrl/Cmd+Shift+R)."
+

--- a/src/rust/lqosd/src/node_manager/js_build/src/circuit.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/circuit.js
@@ -910,7 +910,7 @@ function loadInitial() {
                 up: circuit.upload_max_mbps,
             };
             initialDevices(circuits);
-            speedometer = new BitsPerSecondGauge("bitsGauge");
+            speedometer = new BitsPerSecondGauge("bitsGauge", "Plan");
             totalThroughput = new CircuitTotalGraph("throughputGraph", "Total Circuit Throughput");
             totalRetransmits = new CircuitRetransmitGraph("rxmitGraph", "Total Circuit Retransmits");
             flowSankey = new FlowsSankey("flowSankey");

--- a/src/rust/lqosd/src/node_manager/js_build/src/graphs/bits_gauge.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/graphs/bits_gauge.js
@@ -2,18 +2,35 @@ import {DashboardGraph} from "./dashboard_graph";
 import {scaleNumber} from "../lq_js_common/helpers/scaling";
 
 export class BitsPerSecondGauge extends DashboardGraph {
-    constructor(id) {
+    constructor(id, thresholdLabel = 'Plan') {
         super(id);
+        this.thresholdLabel = thresholdLabel;
         this.option = {
+            graphic: [
+                {
+                    type: 'text',
+                    left: 'center',
+                    top: '4%',
+                    style: {
+                        text: this.thresholdLabel,
+                        fill: '#aaa',
+                        fontSize: 11,
+                        fontWeight: 'bold',
+                        align: 'center'
+                    }
+                }
+            ],
             series: [
                 {
                     type: 'gauge',
+                    splitNumber: 2,
+                    z: 3, // Render Download above Upload
                     axisLine: {
                         lineStyle: {
                             width: 10,
                             color: [
                                 [0.5, 'green'],
-                                [0.8, 'orange'],
+                                [0.75, 'orange'],
                                 [1, '#fd666d']
                             ]
                         }
@@ -21,9 +38,11 @@ export class BitsPerSecondGauge extends DashboardGraph {
                     pointer: {
                         icon: 'path://M2.9,0.7L2.9,0.7c1.4,0,2.6,1.2,2.6,2.6v115c0,1.4-1.2,2.6-2.6,2.6l0,0c-1.4,0-2.6-1.2-2.6-2.6V3.3C0.3,1.9,1.4,0.7,2.9,0.7z',
                         itemStyle: {
-                            color: 'red'
+                            // Download color = blue (palette[0])
+                            color: (typeof window !== 'undefined' && window.graphPalette) ? window.graphPalette[0] : '#4992ff'
                         },
                         width: 4,
+                        length: '85%'
                     },
                     axisTick: {
                         distance: -10,
@@ -35,54 +54,58 @@ export class BitsPerSecondGauge extends DashboardGraph {
                     },
                     splitLine: {
                         distance: -15,
-                        length: 15,
+                        length: 18,
                         lineStyle: {
-                            color: '#999',
+                            color: '#aaa',
                             width: 4
                         }
                     },
                     axisLabel: {
-                        color: 'inherit',
-                        distance: 16,
-                        fontSize: 10,
-                        formatter: (value) => { return scaleNumber(value, 1); }
+                        show: false
                     },
                     detail: {
                         valueAnimation: true,
                         formatter: (value) => { return scaleNumber(value); },
-                        color: 'inherit',
+                        // Download number color = blue
+                        color: (typeof window !== 'undefined' && window.graphPalette) ? window.graphPalette[0] : '#4992ff',
                         fontSize: 12,
                     },
                     title: {
-                        fontSize: 14,
-                        color: 'red',
+                        fontSize: 12,
+                        // Download label color = blue
+                        color: (typeof window !== 'undefined' && window.graphPalette) ? window.graphPalette[0] : '#4992ff',
                     },
                     data: [
                         {
                             name: "DOWN",
                             value: 0,
-                            title: { offsetCenter: ['40%', '75%'] },
-                            detail: { offsetCenter: ['40%', '95%'] },
+                            // Place DOWN on the left side for consistency; shift slightly lower
+                            title: { offsetCenter: ['-45%', '88%'] },
+                            detail: { offsetCenter: ['-45%', '102%'] },
                         }
                     ]
                 },
                 {
                     type: 'gauge',
+                    splitNumber: 2,
+                    z: 2,
                     axisLine: {
                         lineStyle: {
                             width: 10,
                             color: [
                                 [0.5, 'green'],
-                                [0.8, 'orange'],
+                                [0.75, 'orange'],
                                 [1, '#fd666d']
                             ]
                         }
                     },
                     pointer: {
                         itemStyle: {
-                            color: 'orange',
+                            // Upload color = green (palette[1])
+                            color: (typeof window !== 'undefined' && window.graphPalette) ? window.graphPalette[1] : '#7cffb2',
                         },
-                        length: '80%',
+                        length: '85%',
+                        width: 4,
                         icon: 'path://M2.9,0.7L2.9,0.7c1.4,0,2.6,1.2,2.6,2.6v115c0,1.4-1.2,2.6-2.6,2.6l0,0c-1.4,0-2.6-1.2-2.6-2.6V3.3C0.3,1.9,1.4,0.7,2.9,0.7z',
                     },
                     axisTick: {
@@ -95,34 +118,34 @@ export class BitsPerSecondGauge extends DashboardGraph {
                     },
                     splitLine: {
                         distance: -15,
-                        length: 15,
+                        length: 18,
                         lineStyle: {
-                            color: '#999',
+                            color: '#aaa',
                             width: 4
                         }
                     },
                     axisLabel: {
-                        color: 'inherit',
-                        distance: 16,
-                        fontSize: 10,
-                        formatter: (value) => { return scaleNumber(value, 1); }
+                        show: false
                     },
                     detail: {
                         valueAnimation: true,
                         formatter: (value) => { return scaleNumber(value); },
-                        color: 'inherit',
+                        // Upload number color = green
+                        color: (typeof window !== 'undefined' && window.graphPalette) ? window.graphPalette[1] : '#7cffb2',
                         fontSize: 12,
                     },
                     title: {
-                        fontSize: 14,
-                        color: 'orange',
+                        fontSize: 12,
+                        // Upload label color = green
+                        color: (typeof window !== 'undefined' && window.graphPalette) ? window.graphPalette[1] : '#7cffb2',
                     },
                     data: [
                         {
                             name: "UP",
                             value: 0,
-                            title: { offsetCenter: ['-40%', '75%'] },
-                            detail: { offsetCenter: ['-40%', '95%'] },
+                            // Place UP on the right side for consistency; shift slightly lower
+                            title: { offsetCenter: ['45%', '88%'] },
+                            detail: { offsetCenter: ['45%', '102%'] },
                         },
                     ]
                 },
@@ -131,14 +154,56 @@ export class BitsPerSecondGauge extends DashboardGraph {
         this.option && this.chart.setOption(this.option);
     }
 
+    onThemeChange() {
+        // Re-apply palette-based colors when theme toggles
+        try {
+            const blue = (typeof window !== 'undefined' && window.graphPalette) ? window.graphPalette[0] : '#4992ff';
+            const green = (typeof window !== 'undefined' && window.graphPalette) ? window.graphPalette[1] : '#7cffb2';
+            const labelColor = (typeof document !== 'undefined' && document.documentElement.getAttribute('data-bs-theme') === 'dark') ? '#aaa' : '#666';
+
+            // Download (series 0)
+            if (this.option.series[0].pointer && this.option.series[0].pointer.itemStyle) {
+                this.option.series[0].pointer.itemStyle.color = blue;
+            }
+            if (this.option.series[0].detail) {
+                this.option.series[0].detail.color = blue;
+            }
+            if (this.option.series[0].title) {
+                this.option.series[0].title.color = blue;
+            }
+
+            // Upload (series 1)
+            if (this.option.series[1].pointer && this.option.series[1].pointer.itemStyle) {
+                this.option.series[1].pointer.itemStyle.color = green;
+            }
+            if (this.option.series[1].detail) {
+                this.option.series[1].detail.color = green;
+            }
+            if (this.option.series[1].title) {
+                this.option.series[1].title.color = green;
+            }
+
+            // Update threshold label styling/text
+            if (!this.option.graphic) this.option.graphic = [];
+            if (this.option.graphic.length > 0 && this.option.graphic[0].type === 'text') {
+                this.option.graphic[0].style.fill = labelColor;
+                this.option.graphic[0].style.text = this.thresholdLabel || 'Plan';
+            }
+
+            this.chart.setOption(this.option);
+        } catch (_) {
+            // No-op on any unexpected structure
+        }
+    }
+
     update(download, upload, max_down, max_up) {
         this.chart.hideLoading();
         this.option.series[0].data[0].value = download;
         this.option.series[1].data[0].value = upload;
         this.option.series[0].min = 0;
-        this.option.series[0].max = max_down * 1000000; // Convert to bits
+        this.option.series[0].max = (max_down * 2) * 1000000; // 2x plan speed
         this.option.series[1].min = 0;
-        this.option.series[1].max = max_up * 1000000; // Convert to bits
+        this.option.series[1].max = (max_up * 2) * 1000000; // 2x plan speed
         this.chart.setOption(this.option);
     }
 }


### PR DESCRIPTION
Summary

- Improves the circuit “speed gauge” for clarity and consistency.
- Makes 50% explicitly represent the subscriber plan speed (gauge max = 2× plan).
- Aligns colors and layout with other Node Manager charts.
- Adds a tiny dev build helper to speed up UI iteration.

Motivation

- Original dual-pointer gauge had overlapping labels and unclear scale.
- Hard to tell plan speed vs “over plan”.
- Colors didn’t match the rest of the dashboard.
- Minor pointer/label collisions with the gauge.

Key Changes

- Scale and threshold:
    - Gauge max = 2× plan; 50% = plan speed.
    - Color zones: 0–50% green, 50–75% orange, 75–100% red.
    - Prominent split tick at 50% (plan marker).
- Labels and layout:
    - UP on the right (green), DOWN on the left (blue), matching other charts.
    - Pointer lengths unified and shortened to 85% to avoid ring collisions.
    - Title/detail labels lowered to avoid overlapping the ring.
    - Download pointer renders above upload pointer for visibility (z-order).
    - Axis tick labels hidden to prevent clutter/overlap; detail numbers remain.
- Colors and theme:
    - Download uses palette[0] (blue), Upload uses palette[1] (green) for pointer, label, and number.
    - onThemeChange() re-applies palette- and theme-aware colors; “Plan” label adjusts for dark/light.
- “Plan” label at 50%:
    - Centered graphic text above the gauge: default “Plan”.
    - Configurable label (e.g., “Limit”) for reuse as dashboard widget.
- Dev workflow:
    - Added rust/lqosd/dev_build.sh to run esbuild and copy bundles to bin/static2 in one step.

Files

- Updated: src/rust/lqosd/src/node_manager/js_build/src/graphs/bits_gauge.js
- Updated: src/rust/lqosd/src/node_manager/js_build/src/circuit.js (instantiate gauge with “Plan” label)
- Added: rust/lqosd/dev_build.sh

How It Looks Now

- Clear “Plan” threshold at 50% with a strong notch, green up to plan, warning color above.
- UP (green) on the right, DOWN (blue) on the left.
- No text overlaps; numbers and labels have breathing room.
- Pointers don’t touch the ring.

Testing

- Build/copy UI assets quickly:
    - bash rust/lqosd/dev_build.sh
    - Hard refresh the browser (Ctrl/Cmd+Shift+R).
- Verify:
    - 50% split present and labeled “Plan”.
    - Colors match other charts (blue=download, green=upload).
    - Pointers same width and 85% length, not touching the ring.
    - Toggle dark/light mode; gauge recolors correctly.

Notes/Future

- Label is configurable; dashboard usage can pass “Limit” or “Cap” instead of “Plan”.
- If desired, we can expose the zone thresholds (50/75) as configurable.