### PR TITLE
Documentation Update: Remind users to disable SR-IOV

### DIFF
--- a/docs-es/v2.0/prereq-es.md
+++ b/docs-es/v2.0/prereq-es.md
@@ -7,3 +7,7 @@ Desactiva el Hyper-Threading en la BIOS/UEFI de tu sistema host. El Hyper-Thread
 - En sistemas AMD, deberás navegar por las opciones hasta encontrar la opción llamada "SMT Control". Normalmente se encuentra en: ```Advanced -> AMD CBS -> CPU Common Options -> Thread Enablement -> SMT Control``` Una vez localizada, cambia la opción a "Disabled" o "Off".
 - En sistemas Intel, también deberás buscar la opción para desactivar el Hyper-Threading en ajustes. En servidores HP, por ejemplo, está ubicada en: ```System Configuration > BIOS/Platform Configuration (RBSU) > Processor Options > Intel (R) Hyperthreading Options```
 - Guarda los cambios y reinicia el sistema.
+
+## Desactivar SR-IOV en la BIOS
+
+SR-IOV puede desactivar XDP nativo (modo controlador) en las Funciones Físicas (PF), forzando XDP Genérico (SKB) y reduciendo el rendimiento y la estabilidad de LibreQoS. Desactive SR-IOV en la BIOS/UEFI para las tarjetas de red (NIC) utilizadas por LibreQoS. Si existen opciones por ranura/por puerto, desactívelas.

--- a/docs/v2.0/prereq.md
+++ b/docs/v2.0/prereq.md
@@ -1,9 +1,13 @@
 # Server Setup Prerequisites
 
-## Disable Hyper-Threading
+## Disable Hyper-Threading in the BIOS
 Disable hyperthreading on the BIOS/UEFI of your host system. Hyperthreaading is also known as Simultaneous Multi Threading (SMT) on AMD systems. Disabling this is very important for optimal performance of the XDP cpumap filtering and, in turn, throughput and latency.
 
 - Boot, pressing the appropriate key to enter the BIOS settings
 - For AMD systems, you will have to navigate the settings to find the "SMT Control" setting. Usually it is under something like ```Advanced -> AMD CBS -> CPU Common Options -> Thread Enablement -> SMT Control``` Once you find it, switch to "Disabled" or "Off"
 - For Intel systems, you will also have to navigate the settings to find the "hyperthrading" toggle option. On HP servers it's under ```System Configuration > BIOS/Platform Configuration (RBSU) > Processor Options > Intel (R) Hyperthreading Options.```
 - Save changes and reboot
+
+## Disable SR-IOV in the BIOS
+
+SR-IOV can disable XDP native (driver mode) on Physical Functions (PFs), forcing XDP Generic (SKB) and reducing performance and stability for LibreQoS. Disable SR-IOV in BIOS/UEFI for NICs used by LibreQoS. If per-slot/per-port options exist, set them to Disabled.


### PR DESCRIPTION
SR-IOV can disable XDP native (driver mode) on Physical Functions (PFs), forcing XDP Generic (SKB) and reducing performance and stability for LibreQoS. Users should disable SR-IOV in BIOS/UEFI for NICs used by LibreQoS. If per-slot/per-port options exist, set them to Disabled.