### PR TITLE
Restart-safe XDP/TC attach + Insight signup completion UX

### DIFF
--- a/src/rust/lqos_sys/src/lib.rs
+++ b/src/rust/lqos_sys/src/lib.rs
@@ -32,4 +32,5 @@ pub use kernel_wrapper::LibreQoSKernels;
 pub use linux::num_possible_cpus;
 pub use lqos_kernel::interface_name_to_index;
 pub use lqos_kernel::max_tracked_ips;
+pub use lqos_kernel::unload_xdp_from_interface;
 pub use throughput::{HostCounter, throughput_for_each};

--- a/src/rust/lqos_sys/src/lqos_kernel.rs
+++ b/src/rust/lqos_sys/src/lqos_kernel.rs
@@ -13,6 +13,8 @@ use nix::libc::{geteuid, if_nametoindex};
 use std::{
     ffi::{CString, c_void},
     process::Command,
+    thread,
+    time::Duration,
 };
 use tracing::{debug, error, info, warn};
 
@@ -57,19 +59,44 @@ pub fn interface_name_to_index(interface_name: &str) -> Result<u32> {
 }
 
 pub fn unload_xdp_from_interface(interface_name: &str) -> Result<()> {
-    debug!("Unloading XDP/TC");
+    debug!("Unloading XDP/TC on {}", interface_name);
     check_root()?;
-    let interface_index = interface_name_to_index(interface_name)?.try_into()?;
-    unsafe {
-        let err = bpf_xdp_attach(interface_index, -1, 1 << 0, std::ptr::null());
-        if err != 0 {
-            return Err(Error::msg("Unable to unload from interface."));
-        }
+    let ifindex_u32: u32 = interface_name_to_index(interface_name)?;
+    let ifindex_i32: i32 = ifindex_u32.try_into()?;
 
-        let interface_c = CString::new(interface_name)?;
-        let _ = bpf::tc_detach_egress(interface_index, false, true, interface_c.as_ptr());
-        let _ = bpf::tc_detach_ingress(interface_index, false, true, interface_c.as_ptr());
+    // Loop: aggressively attempt detaches across all modes a few times
+    let modes = [XDP_FLAGS_HW_MODE, XDP_FLAGS_DRV_MODE, XDP_FLAGS_SKB_MODE, 0u32];
+    for _ in 0..10 {
+        let mut any_success = false;
+        for flags in modes {
+            let err = unsafe { bpf_xdp_attach(ifindex_i32, -1, flags, std::ptr::null()) };
+            if err == 0 {
+                any_success = true;
+                let mode = match flags {
+                    x if x == XDP_FLAGS_HW_MODE => "HW",
+                    x if x == XDP_FLAGS_DRV_MODE => "DRV",
+                    x if x == XDP_FLAGS_SKB_MODE => "SKB",
+                    _ => "DEFAULT",
+                };
+                debug!("Detached XDP on {} (mode {})", interface_name, mode);
+            }
+        }
+        if !any_success { break; }
+        thread::sleep(Duration::from_millis(10));
     }
+
+    // As a last resort, ask ip(8) to turn off XDP in all modes
+    let _ = Command::new("/bin/ip").args(["link","set",interface_name,"xdp","off"]).output();
+    let _ = Command::new("/bin/ip").args(["link","set",interface_name,"xdpdrv","off"]).output();
+    let _ = Command::new("/bin/ip").args(["link","set",interface_name,"xdpgeneric","off"]).output();
+
+    // Detach TC hooks as well
+    unsafe {
+        let interface_c = CString::new(interface_name)?;
+        let _ = bpf::tc_detach_egress(ifindex_i32, false, true, interface_c.as_ptr());
+        let _ = bpf::tc_detach_ingress(ifindex_i32, false, true, interface_c.as_ptr());
+    }
+
     Ok(())
 }
 
@@ -136,10 +163,11 @@ pub fn attach_xdp_and_tc_to_interface(
             (*(*skeleton).bss).internet_vlan = internet.to_be();
             (*(*skeleton).bss).isp_vlan = isp.to_be();
         }
+        // Ensure no lingering XDP programs before loading/attaching
+        let _ = unload_xdp_from_interface(interface_name);
         load_kernel(skeleton)?;
-        let _ = unload_xdp_from_interface(interface_name); // Ignoring error, it's ok if there isn't one
         let prog_fd = bpf::bpf_program__fd((*skeleton).progs.xdp_prog);
-        attach_xdp_best_available(interface_index, prog_fd)?;
+        attach_xdp_best_available(interface_index, prog_fd, interface_name)?;
         skeleton
     };
 
@@ -220,9 +248,9 @@ pub fn attach_xdp_and_tc_to_interface(
     // This message was worrying people, commented out.
     //println!("{}", String::from_utf8(r.stderr).unwrap());
 
-    // Add the classifier
+    // Ensure clsact qdisc exists (libbpf APIs will create hooks, but this makes state explicit)
     let _r = Command::new("tc")
-        .args(["filter", "add", "dev", interface_name, "clsact"])
+        .args(["qdisc", "add", "dev", interface_name, "clsact"])
         .output()?;
     // This message was worrying people, commented out.
     //println!("{}", String::from_utf8(r.stderr).unwrap());
@@ -289,51 +317,88 @@ pub fn attach_xdp_and_tc_to_interface(
     Ok(skeleton)
 }
 
-unsafe fn attach_xdp_best_available(interface_index: u32, prog_fd: i32) -> Result<()> {
-    // Try hardware offload first
-    if unsafe { try_xdp_attach(interface_index, prog_fd, XDP_FLAGS_HW_MODE).is_err() } {
-        // Try driver attach
-        if unsafe { try_xdp_attach(interface_index, prog_fd, XDP_FLAGS_DRV_MODE).is_err() } {
-            // Try SKB mode
-            if unsafe { try_xdp_attach(interface_index, prog_fd, XDP_FLAGS_SKB_MODE).is_err() } {
-                // Try no flags
-                let error = unsafe {
-                    bpf_xdp_attach(
-                        interface_index.try_into().unwrap(),
-                        prog_fd,
-                        XDP_FLAGS_UPDATE_IF_NOEXIST,
-                        std::ptr::null(),
-                    )
-                };
-                if error != 0 {
-                    return Err(Error::msg("Unable to attach to interface"));
-                }
-            } else {
-                warn!("Attached in SKB compatibility mode. (Not so fast)");
+unsafe fn attach_xdp_best_available(interface_index: u32, prog_fd: i32, iface_name: &str) -> Result<()> {
+    // Helper: attempt attach for a mode with limited retries on EBUSY/EEXIST
+    fn should_retry(errno: i32) -> bool { errno == -16 || errno == -17 }
+
+    unsafe fn try_mode_with_retries(
+        iface_index: u32,
+        prog_fd: i32,
+        mode_flag: Option<u32>,
+        iface_name: &str,
+        max_retries: usize,
+    ) -> Result<(), i32> {
+        let mut attempts = 0;
+        loop {
+            let err = match mode_flag {
+                Some(flag) => bpf_xdp_attach(
+                    iface_index.try_into().unwrap(),
+                    prog_fd,
+                    XDP_FLAGS_UPDATE_IF_NOEXIST | flag,
+                    std::ptr::null(),
+                ),
+                None => bpf_xdp_attach(
+                    iface_index.try_into().unwrap(),
+                    prog_fd,
+                    XDP_FLAGS_UPDATE_IF_NOEXIST,
+                    std::ptr::null(),
+                ),
+            };
+            if err == 0 { return Ok(()); }
+            if should_retry(err) && attempts < max_retries {
+                // Proactively detach any lingering XDP and retry
+                let _ = unload_xdp_from_interface(iface_name);
+                thread::sleep(Duration::from_millis(50));
+                attempts += 1;
+                continue;
             }
-        } else {
-            info!("Attached in driver mode. (Fast)");
+            return Err(err);
         }
-    } else {
-        info!("Attached in hardware accelerated mode. (Fastest)");
     }
-    Ok(())
+
+    // Try hardware offload first
+    match unsafe { try_mode_with_retries(interface_index, prog_fd, Some(XDP_FLAGS_HW_MODE), iface_name, 2) } {
+        Ok(()) => {
+            info!("Attached '{}' in hardware accelerated mode. (Fastest)", iface_name);
+            return Ok(());
+        }
+        Err(_e_hw) => { debug!("XDP attach in HW mode failed (errno: {}), falling back", _e_hw); }
+    }
+
+    // Try driver attach
+    match unsafe { try_mode_with_retries(interface_index, prog_fd, Some(XDP_FLAGS_DRV_MODE), iface_name, 5) } {
+        Ok(()) => {
+            info!("Attached '{}' in driver mode. (Fast)", iface_name);
+            return Ok(());
+        }
+        Err(e_drv) => { debug!("XDP attach in DRV mode failed (errno: {}), falling back", e_drv); }
+    }
+
+    // Try SKB mode
+    match unsafe { try_mode_with_retries(interface_index, prog_fd, Some(XDP_FLAGS_SKB_MODE), iface_name, 5) } {
+        Ok(()) => {
+            info!("Attached '{}' in SKB compatibility mode. (Not so fast)", iface_name);
+            return Ok(());
+        }
+        Err(e_skb) => { debug!("XDP attach in SKB mode failed (errno: {}), falling back", e_skb); }
+    }
+
+    // Try no flags
+    match unsafe { try_mode_with_retries(interface_index, prog_fd, None, iface_name, 3) } {
+        Ok(()) => return Ok(()),
+        Err(error) => {
+            error!(
+                "XDP attach failed on '{}' in all modes (errno: {}). Suggestion: check for existing XDP programs (ip link show, bpftool net), detach with 'ip link set dev {} xdp off', and clear pinned maps if needed.",
+                iface_name,
+                error,
+                iface_name
+            );
+            return Err(Error::msg("Unable to attach to interface"));
+        }
+    }
 }
 
-unsafe fn try_xdp_attach(interface_index: u32, prog_fd: i32, connect_mode: u32) -> Result<()> {
-    let error = unsafe {
-        bpf_xdp_attach(
-            interface_index.try_into().unwrap(),
-            prog_fd,
-            XDP_FLAGS_UPDATE_IF_NOEXIST | connect_mode,
-            std::ptr::null(),
-        )
-    };
-    if error != 0 {
-        return Err(Error::msg("Unable to attach to interface"));
-    }
-    Ok(())
-}
+// (removed) try_xdp_attach: replaced by try_mode_with_retries inside attach_xdp_best_available
 
 // Handle type used to wrap *mut bpf::perf_buffer and indicate
 // that it can be moved. Really unsafe code in theory.

--- a/src/rust/lqosd/src/main.rs
+++ b/src/rust/lqosd/src/main.rs
@@ -46,6 +46,7 @@ use signal_hook::{
 use stats::{BUS_REQUESTS, FLOWS_TRACKED, HIGH_WATERMARK, TIME_TO_POLL_HOSTS};
 use throughput_tracker::flow_data::get_rtt_events_per_second;
 use tracing::{error, info, warn};
+use std::{thread, time::Duration};
 
 // Use MiMalloc only on supported platforms
 //#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -203,6 +204,8 @@ fn main() -> Result<()> {
                                 lts_client::collector::stats_availability::StatsUpdateMessage::Quit,
                             ));
                         std::mem::drop(kernels);
+                        // Give kernel/driver a moment to finalize detach
+                        thread::sleep(Duration::from_millis(50));
                         UnixSocketServer::signal_cleanup();
                         std::mem::drop(file_lock);
                         std::process::exit(0);

--- a/src/rust/lqosd/src/node_manager/js_build/src/lts_trial.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/lts_trial.js
@@ -636,10 +636,13 @@ function attachEventHandlers() {
                     }),
                     contentType: 'application/json',
                 });
+                // Show success message now, then swap spinner to a check and enable dashboard after 5s
+                $('#configStatus').html(`License validated! Your configuration has been updated - data will start going to Insight shortly.`);
                 setTimeout(() => {
-                    $('#configStatus').html(`License validated! Your configuration has been updated - data will start going to Insight shortly.`);
+                    $('#configSpinner').hide();
+                    $('#configStatus').html(`<i class="fas fa-check-circle text-success"></i> Configuration saved.`);
                     $('#btnDashboard').fadeIn();
-                }, 1000);
+                }, 5000);
             } else {
                 hideLoading();
                 showError(response.message || 'Invalid license key.');
@@ -746,10 +749,13 @@ function attachEventHandlers() {
                     }),
                     contentType: 'application/json',
                 });
+                // Show success message now, then swap spinner to a check and enable dashboard after 5s
+                $('#configStatus').html(`Account created! Your configuration has been updated - data will start going to Insight shortly.`);
                 setTimeout(() => {
-                    $('#configStatus').html(`Account created! Your configuration has been updated - data will start going to Insight shortly.`);
+                    $('#configSpinner').hide();
+                    $('#configStatus').html(`<i class="fas fa-check-circle text-success"></i> Configuration saved.`);
                     $('#btnDashboard').fadeIn();
-                }, 1000);
+                }, 5000);
             } else {
                 console.log('[signupForm] No licenseKey in response, error at', new Date().toISOString());
                 showError('Failed to create account. Please try again.');
@@ -761,4 +767,3 @@ function attachEventHandlers() {
         }
     });
 }
-

--- a/src/rust/lqosd/src/remote_commands.rs
+++ b/src/rust/lqosd/src/remote_commands.rs
@@ -47,6 +47,15 @@ fn run_command(command: RemoteCommand) {
             }
         }
         RemoteCommand::RestartLqosd => {
+            // Gracefully detach XDP/TC before exiting to avoid stale attachments
+            if let Ok(cfg) = lqos_config::load_config() {
+                if cfg.on_a_stick_mode() {
+                    let _ = lqos_sys::unload_xdp_from_interface(&cfg.internet_interface());
+                } else {
+                    let _ = lqos_sys::unload_xdp_from_interface(&cfg.internet_interface());
+                    let _ = lqos_sys::unload_xdp_from_interface(&cfg.isp_interface());
+                }
+            }
             std::process::exit(0);
         }
         RemoteCommand::RestartScheduler => {


### PR DESCRIPTION
Summary

- Harden XDP/TC detach/attach to fix restart failures on i40e/X710 and similar.
- Improve attach logging (reduce noise), and correct TC clsact setup.
- Ensure graceful cleanup on SIGTERM and remote RestartLqosd.
- UX: Insight signup page now shows spinner for 5s after success, then a green check and enables “Go to Dashboard”.

Motivation

- LibreQoS users enrolling in the Insight free trial experienced an irrecoverable lqosd failure, wherein the xdp program could not be removed from the interfaces without a restart of the machine.
- Restarting lqosd could fail to reattach XDP due to lingering programs (EBUSY/EEXIST).
- Insight signup UI implied “still working” after success, causing uncertainty.

Core Changes

- Robust detach on startup and shutdown:
    - unload_xdp_from_interface now loops detaching XDP across HW/DRV/SKB/0 modes with a short 10 ms pause between passes, then detaches TC ingress/
egress.
    - Adds ip(8) fallback: runs ip link set <iface> xdp[|drv|generic] off as belt-and‑suspenders.
    - Exported unload_xdp_from_interface from lqos_sys.
- Clean attach sequencing:
    - Always detach existing XDP/TC before loading and attaching new programs.
    - Replace tc filter add ... clsact with correct tc qdisc add ... clsact.
- Attach retries and calmer logs:
    - On EBUSY/EEXIST, proactively detach + retry with 50 ms backoff per attempt.
    - Per‑mode failures (HW/DRV/SKB) log at debug. Only one error if all modes fail.
    - SKB attach logs at info (not warn). HW/DRV attach logs remain info.
    - Removed dead try_xdp_attach helper; replaced by in‑function retry helper with interface context.
- Graceful shutdown paths:
    - SIGTERM: after dropping kernels, sleep 50 ms before exit to let the driver settle.
    - RemoteCommand RestartLqosd: unload XDP/TC on configured interface(s) before exiting.

UX: Insight Signup

- File lts_trial.js: On successful license validate or signup:
    - Show success text immediately.
    - Keep spinner for 5 seconds while lqosd restarts.
    - Then hide spinner, show a green check “Configuration saved.”, and enable “Go to Dashboard”.
- Rationale: avoids users clicking through during the brief service restart window; provides a clear completion signal.

Files Changed

- rust/lqos_sys/src/lib.rs
    - Add pub use lqos_kernel::unload_xdp_from_interface;
    - Add pub use lqos_kernel::unload_xdp_from_interface;
- 
rust/lqos_sys/src/lqos_kernel.rs
    - Overhaul unload_xdp_from_interface: multi‑mode detach loop (10 ms delay), ip(8) fallback, TC detach with proper index types.
    - Ensure detach runs before load_kernel/attach.
    - Fix clsact creation: tc qdisc add dev <iface> clsact.
    - New attach logic attach_xdp_best_available(..., iface_name) with retries on -16/-17 and improved logging.
    - SKB success: info level. Only emit error when all attach modes fail.
    - Remove unused try_xdp_attach.
- 
rust/lqosd/src/main.rs
    - Add 50 ms sleep after dropping kernels on SIGTERM before process exit.
- 
rust/lqosd/src/remote_commands.rs
    - In RestartLqosd, unload XDP/TC on configured interface(s) before exit.
- 
rust/lqosd/src/node_manager/js_build/src/lts_trial.js
    - On success paths, delay spinner removal and enable dashboard after 5s; show green check “Configuration saved.”

Testing

- Restart resilience:
    - systemctl restart lqosd repeatedly; verify attach succeeds in driver or SKB mode.
    - ip link show dev <iface> shows a single XDP attachment.
    - journalctl -u lqosd shows per‑mode failures only at debug; a single error only if attach fails entirely.
- Cleanup correctness:
    - Stop service; verify ip link set dev <iface> xdp off shows no XDP.
    - Check tc qdisc show dev <iface> → no clsact after stop.
- Signup UX:
    - Complete signup; see immediate success text with spinner for ~5s; then green check and “Go to Dashboard” enabled.
    - Click after 5s navigates reliably to dashboard.

Risk/Compatibility

- Requires ip and tc binaries on path (already used elsewhere in code).
- Small 50 ms sleeps add negligible latency to shutdown and retries.

Optional Follow‑ups (not in this PR)

- Consider skipping HW attempt for known non‑offload drivers to reduce noise further.