### PR TITLE
LTS Phase-Out (Step 1): Remove LTS1 submission and anonymous stats

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2297,7 +2297,6 @@ dependencies = [
  "lqos_support_tool",
  "lqos_sys",
  "lqos_utils",
- "lts_client",
  "mimalloc",
  "miniz_oxide",
  "native-tls",

--- a/src/rust/lqosd/Cargo.toml
+++ b/src/rust/lqosd/Cargo.toml
@@ -16,7 +16,6 @@ lqos_sys = { path = "../lqos_sys" }
 lqos_queue_tracker = { path = "../lqos_queue_tracker" }
 lqos_utils = { path = "../lqos_utils" }
 lqos_heimdall = { path = "../lqos_heimdall" }
-lts_client = { path = "../lts_client" }
 lqos_support_tool = { path = "../lqos_support_tool" }
 lqos_stormguard = { path = "../lqos_stormguard" }
 tokio = { version = "1", features = [ "full" ] }

--- a/src/rust/lqosd/src/long_term_stats/mod.rs
+++ b/src/rust/lqosd/src/long_term_stats/mod.rs
@@ -1,47 +1,15 @@
-//! Most of this functionality is now in the` lts_stats` crate.
-use crate::shaped_devices_tracker::NETWORK_JSON;
+//! LTS1 (legacy) statistics have been removed. These stubs keep
+//! bus handlers compiling, returning a clear "No Data" response.
 use lqos_bus::BusResponse;
-use lts_client::{collector::NetworkTreeEntry, submission_queue::get_current_stats};
-
-pub(crate) fn get_network_tree() -> Vec<(usize, NetworkTreeEntry)> {
-    let result = NETWORK_JSON
-        .read()
-        .unwrap()
-        .get_nodes_when_ready()
-        .iter()
-        .enumerate()
-        .map(|(idx, n)| (idx, n.into()))
-        .collect::<Vec<(usize, NetworkTreeEntry)>>();
-    //println!("{result:#?}");
-    result
-}
 
 pub fn get_stats_totals() -> BusResponse {
-    let current = get_current_stats();
-    if let Some(c) = current {
-        if let Some(totals) = &c.totals {
-            return BusResponse::LongTermTotals(totals.clone());
-        }
-    }
     BusResponse::Fail("No Data".to_string())
 }
 
 pub fn get_stats_host() -> BusResponse {
-    let current = get_current_stats();
-    if let Some(c) = current {
-        if let Some(hosts) = c.hosts {
-            return BusResponse::LongTermHosts(hosts);
-        }
-    }
     BusResponse::Fail("No Data".to_string())
 }
 
 pub fn get_stats_tree() -> BusResponse {
-    let current = get_current_stats();
-    if let Some(c) = current {
-        if let Some(tree) = c.tree {
-            return BusResponse::LongTermTree(tree);
-        }
-    }
     BusResponse::Fail("No Data".to_string())
 }

--- a/src/rust/lqosd/src/throughput_tracker/mod.rs
+++ b/src/rust/lqosd/src/throughput_tracker/mod.rs
@@ -17,15 +17,11 @@ use lqos_bus::{BusResponse, FlowbeeProtocol, IpStats, TcHandle, TopFlowType, Xdp
 use lqos_sys::flowbee_data::FlowbeeKey;
 use lqos_utils::units::{DownUpOrder, down_up_divide};
 use lqos_utils::{XdpIpAddress, hash_to_i64, unix_time::time_since_boot};
-use lts_client::collector::stats_availability::StatsUpdateMessage;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use timerfd::{SetTimeFlags, TimerFd, TimerState};
-use tokio::{
-    sync::mpsc::Sender,
-    time::{Duration, Instant},
-};
+use tokio::time::{Duration, Instant};
 use tracing::{debug, warn};
 
 const RETIRE_AFTER_SECONDS: u64 = 30;
@@ -40,7 +36,6 @@ pub static THROUGHPUT_TRACKER: Lazy<ThroughputTracker> = Lazy::new(ThroughputTra
 /// * `long_term_stats_tx` - an optional MPSC sender to notify the
 ///   collection thread that there is fresh data.
 pub fn spawn_throughput_monitor(
-    long_term_stats_tx: Sender<StatsUpdateMessage>,
     netflow_sender: crossbeam_channel::Sender<(FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>,
     system_usage_actor: crossbeam_channel::Sender<tokio::sync::oneshot::Sender<SystemStats>>,
     bakery_sender: crossbeam_channel::Sender<lqos_bakery::BakeryCommands>,
@@ -48,7 +43,7 @@ pub fn spawn_throughput_monitor(
     debug!("Starting the bandwidth monitor thread.");
     std::thread::Builder::new()
         .name("Throughput Monitor".to_string())
-        .spawn(|| throughput_task(long_term_stats_tx, netflow_sender, system_usage_actor, bakery_sender))?;
+        .spawn(|| throughput_task(netflow_sender, system_usage_actor, bakery_sender))?;
 
     Ok(())
 }
@@ -103,7 +98,6 @@ impl ThroughputTaskTimeMetrics {
 }
 
 fn throughput_task(
-    long_term_stats_tx: Sender<StatsUpdateMessage>,
     netflow_sender: crossbeam_channel::Sender<(FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>,
     system_usage_actor: crossbeam_channel::Sender<tokio::sync::oneshot::Sender<SystemStats>>,
     bakery_sender: crossbeam_channel::Sender<BakeryCommands>,
@@ -130,7 +124,7 @@ fn throughput_task(
         false
     };
 
-    let mut last_submitted_to_lts: Option<Instant> = None;
+    let mut last_submit: Option<Instant> = None;
     let mut tfd = match TimerFd::new() {
         Ok(t) => t,
         Err(e) => {
@@ -202,26 +196,22 @@ fn throughput_task(
             TIME_TO_POLL_HOSTS.store(duration_ms as u64, std::sync::atomic::Ordering::Relaxed);
         }
 
-        if last_submitted_to_lts.is_none() {
+        // Submit to Insight only (LTS1 removed)
+        if last_submit.is_none() {
             stats_submission::submit_throughput_stats(
-                long_term_stats_tx.clone(),
                 1.0,
                 stats_counter,
                 system_usage_actor.clone(),
             );
         } else {
-            let elapsed = last_submitted_to_lts.unwrap().elapsed();
+            let elapsed = last_submit.unwrap().elapsed();
             let elapsed_f64 = elapsed.as_secs_f64();
-            // Temporary: place this in a thread to not block the timer
-            let my_lts_tx = long_term_stats_tx.clone();
-            let my_system_usage_actor = system_usage_actor.clone();
-            // Submit if a reasonable amount of time has passed - drop if there was a long hitch
             if elapsed_f64 < 2.0 {
+                let my_system_usage_actor = system_usage_actor.clone();
                 std::thread::Builder::new()
                     .name("Throughput Stats Submit".to_string())
                     .spawn(move || {
                         stats_submission::submit_throughput_stats(
-                            my_lts_tx,
                             elapsed_f64,
                             stats_counter,
                             my_system_usage_actor,
@@ -232,8 +222,8 @@ fn throughput_task(
                     .unwrap();
             }
         }
-        last_submitted_to_lts = Some(Instant::now());
-        timer_metrics.lts_submit = timer_metrics.start.elapsed().as_secs_f64();
+        last_submit = Some(Instant::now());
+        // timer_metrics.lts_submit retained for profiling if needed
 
         // Counter for occasional stats
         stats_counter = stats_counter.wrapping_add(1);


### PR DESCRIPTION
- Summary: Retires LTS1 paths from lqosd and disables anonymous stats submission, moving telemetry to Insight-only while keeping existing APIs stable.
- Changes:
    - lqosd
    - Removed dependency on `lts_client` in `rust/lqosd/Cargo.toml`.
    - Deleted LTS1 startup/quit handling in `src/main.rs`.
    - Throughput monitor now submits Insight-only; removed LTS1 channel wiring in `throughput_tracker/mod.rs`.
    - `throughput_tracker/stats_submission.rs`: stripped LTS1 host/summary types and queue signaling; Insight submissions
unchanged.
    - Anonymous stats: disabled startup (`anonymous_usage::start_anonymous_usage()` no longer called).
    - `long_term_stats/mod.rs`: replaced LTS1 accessors with stubs returning “No Data” to preserve bus API.
- No DNS shim introduced; no queue behavior changes.
- Compatibility:
    - Insight (LTS2) submission and license check unaffected.
    - Bus routes for long-term stats remain but return “No Data”, avoiding immediate breakage of any consumers.
    - LTS1 crate remains in the workspace for type references in other crates; lqosd no longer links or calls it.
- Rationale: Align with deprecating LTS1 and reduce moving parts before retry/DNS hardening. Prevents the LTS1 path from stalling submissions.
- Testing:
    - Workspace compiles (cargo check in rust/).
    - lqosd builds without lts_client; startup order and Insight submission paths remain intact.
- Risks:
    - Any tooling expecting LTS1 data via bus will now receive “No Data”.
    - If desired later, we can fully remove the lts_client crate after migrating a few shared types used by lqos_bus.
- Next steps (separate PRs):
    - Harden LTS2 license loop (never exit on errors, adaptive retry, clearer logs).
    - Harden LTS2 ingest loop logging/retry behavior (no buffering changes).
    - Only if needed after loop hardening: add scoped DNS fallback for insight.libreqos.com with serde-default config.
