### PR TITLE
Deduplicate UISP shaped device output

### DIFF
--- a/src/rust/uisp_integration/src/strategies/ap_site.rs
+++ b/src/rust/uisp_integration/src/strategies/ap_site.rs
@@ -80,6 +80,8 @@ pub(crate) fn write_shaped_devices(
     shaped_devices: &mut Vec<ShapedDevice>,
 ) -> Result<(), UispIntegrationError> {
     let file_path = Path::new(&config.lqos_directory).join("ShapedDevices.csv");
+    let mut seen_pairs = HashSet::new();
+    shaped_devices.retain(|sd| seen_pairs.insert((sd.circuit_id.clone(), sd.device_id.clone())));
     let mut writer = csv::WriterBuilder::new()
         .has_headers(true)
         .from_path(file_path)

--- a/src/rust/uisp_integration/src/strategies/common.rs
+++ b/src/rust/uisp_integration/src/strategies/common.rs
@@ -5,7 +5,7 @@ use crate::strategies::full::parse::parse_uisp_datasets;
 use crate::strategies::full::uisp_fetch::load_uisp_data;
 use crate::uisp_types::{UispDevice, UispSite, UispSiteType};
 use lqos_config::Config;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::warn;
 use uisp::{DataLink, Device, Site};
@@ -89,7 +89,7 @@ impl UispData {
     }
 
     pub fn map_clients_to_aps(&self) -> HashMap<String, Vec<String>> {
-        let mut mappings = HashMap::new();
+        let mut mappings: HashMap<String, HashSet<String>> = HashMap::new();
         for client in self.find_client_sites() {
             let mut found = false;
             let mut parent = None;
@@ -190,16 +190,25 @@ impl UispData {
                 //println!("Client {} has no obvious parent AP", client.name);
                 let entry = mappings
                     .entry("Orphans".to_string())
-                    .or_insert_with(Vec::new);
-                entry.push(client.id.clone());
+                    .or_insert_with(HashSet::new);
+                entry.insert(client.id.clone());
             } else {
                 //info!("Client {} is connected to {:?}", client.name, parent);
                 if let Some((_, parent)) = &parent {
-                    let entry = mappings.entry(parent.to_string()).or_insert_with(Vec::new);
-                    entry.push(client.id.clone());
+                    let entry = mappings
+                        .entry(parent.to_string())
+                        .or_insert_with(HashSet::new);
+                    entry.insert(client.id.clone());
                 }
             }
         }
         mappings
+            .into_iter()
+            .map(|(ap, sites)| {
+                let mut sites_vec: Vec<_> = sites.into_iter().collect();
+                sites_vec.sort();
+                (ap, sites_vec)
+            })
+            .collect()
     }
 }

--- a/src/rust/uisp_integration/src/strategies/flat.rs
+++ b/src/rust/uisp_integration/src/strategies/flat.rs
@@ -4,6 +4,7 @@ use crate::ip_ranges::IpRanges;
 use crate::uisp_types::UispDevice;
 use lqos_config::Config;
 use serde::Serialize;
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -77,6 +78,7 @@ pub async fn build_flat_network(
 
     // Simple Shaped Devices File
     let mut shaped_devices = Vec::new();
+    let mut seen_pairs = HashSet::new();
     let ipv4_to_v6 = Vec::new();
     for site in sites.iter() {
         if let Some(site_id) = &site.identification {
@@ -183,6 +185,11 @@ pub async fn build_flat_network(
                         let dev = UispDevice::from_uisp(device, &config, &ip_ranges, &ipv4_to_v6);
                         if dev.site_id == site.id {
                             // We're an endpoint in the right sight. We're getting there
+                            let key = (site.id.clone(), device.get_id());
+                            if !seen_pairs.insert(key) {
+                                continue;
+                            }
+
                             let sd = ShapedDevice {
                                 circuit_id: site.id.clone(),
                                 circuit_name: site.name_or_blank(),

--- a/src/rust/uisp_integration/src/strategies/full2.rs
+++ b/src/rust/uisp_integration/src/strategies/full2.rs
@@ -368,6 +368,7 @@ pub async fn build_full_network_v2(
 
     // Shaped Devices
     let mut shaped_devices = Vec::new();
+    let mut seen_pairs = HashSet::new();
 
     for (ap_id, client_sites) in client_mappings.iter() {
         for site_id in client_sites.iter() {
@@ -433,6 +434,11 @@ pub async fn build_full_network_v2(
                         "Orphans".to_string()
                     }
                 };
+
+                let key = (site.id.clone(), device.id.clone());
+                if !seen_pairs.insert(key) {
+                    continue;
+                }
 
                 let shaped_device = ShapedDevice {
                     circuit_id: site.id.to_owned(),
@@ -897,9 +903,9 @@ fn find_point_to_point_squash_candidates(
 
                 // Endpoint must not be a relay AND must have sufficient connections to be meaningful
                 // Also prefer Sites over AccessPoints as endpoints
-                let is_meaningful_endpoint = !(endpoint_b_degree == 4 && endpoint_b_neighbors.len() == 2) && 
-                                           endpoint_b_neighbors.len() >= 3 && // Must connect to at least 3 other nodes
-                                           !matches!(graph[endpoint_b], GraphMapping::AccessPoint { .. }); // Avoid APs as endpoints
+                let is_meaningful_endpoint = !(endpoint_b_degree == 4 && endpoint_b_neighbors.len() == 2)
+                        && endpoint_b_neighbors.len() >= 3 // Must connect to at least 3 other nodes
+                        && !matches!(graph[endpoint_b], GraphMapping::AccessPoint { .. }); // Avoid APs as endpoints
                 if is_meaningful_endpoint {
                     // Check do_not_squash_sites - skip if any node in the chain is in the exclusion list
                     let do_not_squash = &config
@@ -997,9 +1003,9 @@ fn find_point_to_point_squash_candidates(
 
                 // Endpoint must not be a relay AND must have sufficient connections to be meaningful
                 // Also prefer Sites over AccessPoints as endpoints
-                let is_meaningful_endpoint = !(endpoint_a_degree == 4 && endpoint_a_neighbors.len() == 2) && 
-                                           endpoint_a_neighbors.len() >= 3 && // Must connect to at least 3 other nodes
-                                           !matches!(graph[endpoint_a], GraphMapping::AccessPoint { .. }); // Avoid APs as endpoints
+                let is_meaningful_endpoint = !(endpoint_a_degree == 4 && endpoint_a_neighbors.len() == 2)
+                        && endpoint_a_neighbors.len() >= 3 // Must connect to at least 3 other nodes
+                        && !matches!(graph[endpoint_a], GraphMapping::AccessPoint { .. }); // Avoid APs as endpoints
                 if is_meaningful_endpoint {
                     // Check do_not_squash_sites - skip if any node in the chain is in the exclusion list
                     let do_not_squash = &config


### PR DESCRIPTION
- Ensure map_clients_to_aps returns unique client-site IDs and guard full-network writer against duplicate (site, device) pairs
- Add per-strategy de-dupe for ap_only, flat, and ap_site so router-mode subscribers or graph traversal quirks can’t double-write devices
- Keep CSV emission deterministic by sorting client lists while preserving existing
rate calculations