### PR TITLE
Support tool retire

### DIFF
--- a/src/build_dpkg.sh
+++ b/src/build_dpkg.sh
@@ -56,7 +56,6 @@ RUSTPROGS=(
   lqos_setup
   lqos_map_perf
   uisp_integration
-  lqos_support_tool
 )
 
 ####################################################
@@ -89,8 +88,17 @@ popd > /dev/null || exit
 
 # Build the Rust programs (before the control file, we need to LDD lqosd)
 pushd rust > /dev/null || exit
-#cargo clean
-cargo build --all --release
+# Build only required binaries and artifacts (exclude lqos_support_tool executable)
+cargo build --release \
+  -p lqosd \
+  -p lqtop \
+  -p xdp_iphash_to_cpu_cmdline \
+  -p xdp_pping \
+  -p lqusers \
+  -p lqos_setup \
+  -p lqos_map_perf \
+  -p uisp_integration \
+  -p lqos_python
 popd > /dev/null || exit
 
 # Create the post-installation file

--- a/src/build_rust.sh
+++ b/src/build_rust.sh
@@ -38,7 +38,7 @@ rustup update
 
 # Start building
 echo "Please wait while the system is compiled. Service will not be interrupted during this stage."
-PROGS="lqosd lqtop xdp_iphash_to_cpu_cmdline xdp_pping lqusers lqos_map_perf uisp_integration lqos_support_tool"
+PROGS="lqosd lqtop xdp_iphash_to_cpu_cmdline xdp_pping lqusers lqos_map_perf uisp_integration"
 mkdir -p bin/static
 pushd rust > /dev/null || exit
 #cargo clean

--- a/src/rust/lqosd/src/node_manager/local_api.rs
+++ b/src/rust/lqosd/src/node_manager/local_api.rs
@@ -37,8 +37,6 @@ pub fn local_api(shaper_query: tokio::sync::mpsc::Sender<ShaperQueryCommand>) ->
         .route("/devicesAll", get(shaped_device_api::all_shaped_devices))
         .route("/networkTree", get(network_tree::get_network_tree))
         .route("/sanity", get(support::run_sanity_check))
-        .route("/gatherSupport", post(support::gather_support_data))
-        .route("/submitSupport", post(support::submit_support_data))
         .route("/ltsCheck", get(lts::stats_check))
         .route("/search", post(search::search))
         .route("/unknownIps", get(unknown_ips::unknown_ips))

--- a/src/rust/lqosd/src/node_manager/local_api/support.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/support.rs
@@ -1,71 +1,9 @@
 use axum::Json;
-use axum::body::Body;
-use axum::http::header;
-use axum::response::IntoResponse;
-use lqos_config::load_config;
 use lqos_support_tool::{SanityChecks, run_sanity_checks};
-use serde::Deserialize;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 pub async fn run_sanity_check() -> Json<SanityChecks> {
     let mut status = run_sanity_checks(false)
         .expect("Failed to run sanity checks");
     status.results.sort_by(|a, b| a.success.cmp(&b.success));
     Json(status)
-}
-
-#[derive(Deserialize, Clone)]
-pub struct SupportMetadata {
-    name: String,
-    comment: String,
-}
-
-pub async fn gather_support_data(info: Json<SupportMetadata>) -> impl IntoResponse {
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("SystemTime is before UNIX_EPOCH")
-        .as_secs();
-    let filename = format!("libreqos_{}.support", timestamp);
-    let lts_key = if let Ok(cfg) = load_config() {
-        cfg.long_term_stats
-            .license_key
-            .clone()
-            .unwrap_or("None".to_string())
-    } else {
-        "None".to_string()
-    };
-    let dump = lqos_support_tool::gather_all_support_info(&info.name, &info.comment, &lts_key)
-        .expect("Failed to gather support information");
-
-    let body = Body::from(
-        dump.serialize_and_compress()
-            .expect("Failed to serialize/compress support bundle"),
-    );
-    let headers = [
-        (header::CONTENT_TYPE, "application/octet-stream"),
-        (
-            header::CONTENT_DISPOSITION,
-            &format!("attachment; filename=\"{filename}\""),
-        ),
-    ];
-    (headers, body).into_response()
-}
-
-pub async fn submit_support_data(info: Json<SupportMetadata>) -> String {
-    let lts_key = if let Ok(cfg) = load_config() {
-        cfg.long_term_stats
-            .license_key
-            .clone()
-            .unwrap_or("None".to_string())
-    } else {
-        "None".to_string()
-    };
-    if let Ok(dump) =
-        lqos_support_tool::gather_all_support_info(&info.name, &info.comment, &lts_key)
-    {
-        lqos_support_tool::submit_to_network(dump);
-        "Your support submission has been sent".to_string()
-    } else {
-        "Something went wrong".to_string()
-    }
 }

--- a/src/rust/lqosd/src/node_manager/static2/help.html
+++ b/src/rust/lqosd/src/node_manager/static2/help.html
@@ -11,9 +11,9 @@
                 </p>
                 <p>
                     <a href="https://github.com/sponsors/LibreQoE/" class="btn btn-primary">
-                        <i class="fa fa-money"></i> Support LibreQoS Today
+                        <i class="fa fa-dollar-sign"></i> Support LibreQoS Today
                     </a>
-                    <button class="btn btn-outline-primary" type="button" id="btnDave">
+                    <button class="btn btn-outline-primary mt-2" type="button" id="btnDave">
                         In Memory of Dave Täht
                     </button>
                 </p>
@@ -46,7 +46,7 @@
     <div class="col-4">
         <div class="card">
             <div class="card-body">
-                <h5 class="card-title"><i class="fa fa-youtube"></i> Learn</h5>
+                <h5 class="card-title"><i class="fab fa-youtube"></i> Learn</h5>
                 <p>
                     Learn about LibreQoS, bufferbloat and our battle against Internet
                     latency at our <a href="https://www.youtube.com/@LibreQoS">YouTube channel</a>.
@@ -58,13 +58,13 @@
     <div class="col-4">
         <div class="card">
             <div class="card-body">
-                <h5 class="card-title"><i class="fa fa-connectdevelop"></i> Connect</h5>
+                <h5 class="card-title"><i class="fab fa-connectdevelop"></i> Connect</h5>
                 <p>
                     We're on social media! Connect with us at:
                     <ul>
-                        <li><a href="https://www.linkedin.com/company/libreqos/"><i class="fa fa-linkedin"></i> LinkedIn</a></li>
-                        <li><a href="https://twitter.com/libreqos"><i class="fa fa-twitter"></i> Twitter</a></li>
-                        <li><a href="https://www.facebook.com/libreqos"><i class="fa fa-facebook"></i> Facebook</a></li>
+                        <li><a href="https://www.linkedin.com/company/libreqos/"><i class="fab fa-linkedin"></i> LinkedIn</a></li>
+                        <li><a href="https://twitter.com/libreqos"><i class="fab fa-twitter"></i> Twitter</a></li>
+                        <li><a href="https://www.facebook.com/libreqos"><i class="fab fa-facebook"></i> Facebook</a></li>
                         <li><a href="https://fosstodon.org/@LibreQoS/"><i class="fa fa-link"></i> Fosstodon (Free Open Source Mastadon)</a></li>
                     </ul>
             </div>
@@ -75,7 +75,7 @@
         <div class="card">
             <div class="card-body">
                 <h5 class="card-title"><i class="fa fa-wrench"></i> Tools</h5>
-                <p style="border: 1px solid #eee">
+                <p>
                     <strong>Sanity check</strong> reads your configuration and looks for common issues. This should be
                     your first step when troubleshooting the system.<br />
                     <button id="btnSanity" class="btn btn-primary"><i class="fa fa-info"></i> Sanity Check Your Installation</button>

--- a/src/rust/lqosd/src/node_manager/static2/help.html
+++ b/src/rust/lqosd/src/node_manager/static2/help.html
@@ -80,17 +80,7 @@
                     your first step when troubleshooting the system.<br />
                     <button id="btnSanity" class="btn btn-primary"><i class="fa fa-info"></i> Sanity Check Your Installation</button>
                 </p>
-                <p style="border: 1px solid #eee">
-                    <strong>Download</strong> support data to a local file. You can send this to LibreQoS via the
-                    chat or email (as part of an ongoing support discussion).<br />
-                    <button id="btnDownload" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#downloadDump"><i class="fa fa-download"></i> Download Support Dump</button>
-                </p>
-                <p style="border: 1px solid #eee">
-                    <strong>Submit</strong> support data directly to LibreQoS. Please contact us when you do this,
-                    with detailed information about the problems you are experiencing. Repeatedly hitting this
-                    button will get you slower - or no - service!<br />
-                    <button id="btnSubmit" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#submitDump"><i class="fa fa-send"></i> Send Support Dump</button>
-                </p>
+                <!-- Support dump download/submission removed; server discontinued -->
 
             </div>
         </div>
@@ -114,73 +104,6 @@
     </div>
 </div>
 
-<div class="modal" tabindex="-1" id="downloadDump">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Information To Add to the Support Dump</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body" style="overflow: auto;">
-                <div class="row">
-                    <div class="col">
-                        <label for="gatherName" class="form-label">Your Name</label>
-                        <input type="text" id="gatherName" class="form-control" />
-                    </div>
-                    <div class="col">
-                        <label for="gatherEmail" class="form-label">Your Email Address</label>
-                        <input type="text" id="gatherEmail" class="form-control" />
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col">
-                        <label for="gatherComments" class="form-label">Comments</label>
-                        <input type="text" id="gatherComments" class="form-control" />
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button id="btnGather" type="button" class="btn btn-primary"><i class="fa fa-download"></i> Generate and Download</button>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
-
-<div class="modal" tabindex="-1" id="submitDump">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Information To Add to the Support Dump</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body" style="overflow: auto;">
-                <p class="alert-warning"><i class="fa fa-warning"></i> Your support dump will contain unredated data about your customers, and lots
-                    of information about your server. By submitting, you are acknowledging that LibreQoS bear no liability for this data.
-                    LibreQoS will take all reasonable measures to protect your data, and will not share it.</p>
-                <div class="row">
-                    <div class="col">
-                        <label for="submitName" class="form-label">Your Name</label>
-                        <input type="text" id="submitName" class="form-control" />
-                    </div>
-                    <div class="col">
-                        <label for="submitEmail" class="form-label">Your Email Address</label>
-                        <input type="text" id="submitEmail" class="form-control" />
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col">
-                        <label for="submitComments" class="form-label">Comments</label>
-                        <input type="text" id="submitComments" class="form-control" />
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button id="btnClickSub" type="button" class="btn btn-primary"><i class="fa fa-send"></i> Submit Support Data to LibreQoS</button>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
+<!-- Removed support dump modals: downloadDump and submitDump -->
 
 <script src="help.js%CACHEBUSTERS%"></script>


### PR DESCRIPTION
Since we're retiring long term stats (in favour of Insight), and the support tool submits to LTS - this PR removes the tool from the distribution and the help page. The help page also gets a spring cleaning.