### PR TITLE
Clamp cpu_map to host's possible CPU count

### DIFF
--- a/src/rust/lqos_sys/src/lqos_kernel.rs
+++ b/src/rust/lqos_sys/src/lqos_kernel.rs
@@ -469,6 +469,15 @@ pub fn attach_xdp_and_tc_to_interface(
     let skeleton = unsafe {
         let skeleton = open_kernel()?;
         (*(*skeleton).rodata).NUM_CPUS = libbpf_num_possible_cpus();
+        // Kernel rejects CPUMAP maps larger than its compile time NR_CPUS (-E2BIG)
+        // Clamp cpu_map to host possible CPU count capped at MAX_CPUS (common/maximums.h)
+        // Resizing the pinned map will require either remove_pinned_maps.sh or reboot
+        let cpu_map_entries = crate::num_possible_cpus()?.min(1024);
+        let error = bpf::bpf_map__set_max_entries((*skeleton).maps.cpu_map, cpu_map_entries);
+        if error != 0 {
+            error!("Unable to resize cpu_map to {cpu_map_entries} entries ({error})");
+            return Err(Error::msg("Unable to resize cpu_map"));
+        }
         (*(*skeleton).data).direction = match direction {
             InterfaceDirection::Internet => 1,
             InterfaceDirection::IspNetwork => 2,


### PR DESCRIPTION
Hello! I'm working with NGI summer of nix program https://ngi.nixos.org and trying to package LibreQoS for NixOS in https://github.com/NixOS/nixpkgs/pull/549846

during test, i found that lqosd is crashing in loops:

```
...
machine # [   15.283708] lqosd[875]: Error: Unable to load the XDP/TC kernel (-7)
machine # [   15.287242] systemd[1]: lqosd.service: Failed with result 'exit-code'.
machine # [   15.624564] systemd[1]: lqosd.service: Scheduled restart job, restart counter is at 1.
machine # [   16.160958] lqosd[923]: Error: Unable to load the XDP/TC kernel (-7)
...
```

from https://github.com/LibreQoE/LibreQoS/blob/861c0ed44424038321782bff5dae1f95e88b4530/src/rust/lqos_sys/src/lqos_kernel.rs#L271

to get more context i tried directly loading the bpf object files and that got me `libbpf: map 'cpu_map': failed to create: -E2BIG`

apparently max_entries is hard coded to be 1024:

https://github.com/LibreQoE/LibreQoS/blob/861c0ed44424038321782bff5dae1f95e88b4530/src/rust/lqos_sys/src/bpf/common/cpu_map.h#L22

https://github.com/LibreQoE/LibreQoS/blob/main/src/rust/lqos_sys/src/bpf/common/maximums.h#L10

it seems to me that max entry setting is guarded by CONFIG_NR_CPUS in kconfig, and the default value on nixos is 384: https://github.com/NixOS/nixpkgs/blob/b5a1961b9c902670dc7fb9beced49f2e64ace761/pkgs/os-specific/linux/kernel/common-config.nix#L1531 which makes sense that it failed


IMO this is a less invasive fix that modifies the loaded object file and change the map's max entry before bpf syscall is invoked, and is dynamic based on a preexisting helper at https://github.com/LibreQoE/LibreQoS/blob/861c0ed44424038321782bff5dae1f95e88b4530/src/rust/lqos_sys/src/linux/possible_cpus.rs#L11 