### PR TITLE
Fix download capacity accessor on asymmetric links

### DIFF
--- a/src/rust/lqos_python/src/lib.rs
+++ b/src/rust/lqos_python/src/lib.rs
@@ -2125,7 +2125,7 @@ fn fast_queues_fq_codel() -> PyResult<f32> {
 #[pyfunction]
 fn upstream_bandwidth_capacity_download_mbps() -> PyResult<u32> {
     let config = lqos_config::load_config().unwrap();
-    Ok(config.queues.uplink_bandwidth_mbps as u32)
+    Ok(config.queues.downlink_bandwidth_mbps as u32)
 }
 
 #[pyfunction]


### PR DESCRIPTION
## Summary

- return the configured downlink capacity from `upstream_bandwidth_capacity_download_mbps()`
- prevent asymmetric links from using the uplink capacity as the download ceiling

Fixes #1151

## Validation

- `cargo check -p lqos_python`
- `cargo test -p lqos_python` (7 passed)
- `cargo clippy -p lqos_python -- -D warnings`
- `rustfmt --edition 2024 --check rust/lqos_python/src/lib.rs`
- `git diff --check`