### PR TITLE
Fix API Docs behind managed Caddy HTTPS

### DIFF
--- a/docs-es/v2.0/api-es.md
+++ b/docs-es/v2.0/api-es.md
@@ -21,7 +21,7 @@ El acceso solo a la API está disponible mediante el enlace **Try Insight** de l
 Use Swagger en su nodo como referencia completa y superficie de prueba para la versión instalada:
 
 - Puerto local directo de la API: `http://<node-ip>:9122/api-docs`
-- Si la WebUI usa HTTPS opcional con Caddy: `https://<hostname-o-ip-del-nodo>/api/v1/api-docs`
+- Si la WebUI usa HTTPS opcional con Caddy: `https://<hostname-o-ip-del-nodo>/api-docs/`
 
 En sistemas que usan HTTPS con Caddy gestionado, deje el listener de la API en loopback y acceda a la API mediante `/api/v1/`. `LQOS_API_LISTEN` es un override avanzado para despliegues que exponen intencionalmente el listener de la API en forma directa; no lo configure en sistemas con Caddy gestionado salvo que la exposición directa, el firewall, TLS y los controles de acceso de operadores se hayan planificado juntos.
 

--- a/docs-es/v2.0/https-caddy-es.md
+++ b/docs-es/v2.0/https-caddy-es.md
@@ -21,7 +21,11 @@ LibreQoS ofrece dos opciones simples:
 - LibreQoS mueve el listener de la WebUI a `127.0.0.1:9123`.
 - Caddy publica la WebUI y la documentación de la API por HTTPS.
 - En modo Caddy gestionado, las solicitudes de API se envían a `127.0.0.1:9122`, de modo que la API queda detrás del mismo origen HTTPS que la WebUI.
-- Swagger pasa a `/api/v1/api-docs` en el mismo origen HTTPS de la WebUI.
+- Swagger pasa a `/api-docs/` en el mismo origen HTTPS de la WebUI.
+
+La documentación de la API es pública; las solicitudes a la API siguen requiriendo una clave de API. Los enlaces existentes a `/api/v1/api-docs` redirigen a `/api-docs/`.
+
+Tras actualizar una instalación que ya usa HTTPS, vuelva a aplicar los ajustes en `Configuration -> SSL Setup` para actualizar las rutas de Caddy. Esto regenera `/etc/caddy/Caddyfile`, reemplaza las modificaciones manuales y reinicia Caddy, la WebUI y el servicio de API.
 
 ## Overrides del listener de la API
 

--- a/docs/v2.0/api.md
+++ b/docs/v2.0/api.md
@@ -21,7 +21,7 @@ API-only access is available through the **Try Insight** link in the WebUI at ha
 Use Swagger on your node as the complete reference and test surface for your installed build:
 
 - Direct local API port: `http://<node-ip>:9122/api-docs`
-- If optional HTTPS with Caddy is enabled for the WebUI: `https://<hostname-or-node-ip>/api/v1/api-docs`
+- If optional HTTPS with Caddy is enabled for the WebUI: `https://<hostname-or-node-ip>/api-docs/`
 
 On systems using managed Caddy HTTPS, leave the API listener on loopback and access it through `/api/v1/`. `LQOS_API_LISTEN` is an advanced override for deployments that intentionally expose the API listener directly; do not set it on managed Caddy systems unless direct API exposure, firewalling, TLS, and operator access controls have been planned together.
 

--- a/docs/v2.0/https-caddy.md
+++ b/docs/v2.0/https-caddy.md
@@ -21,7 +21,11 @@ LibreQoS supports two simple choices:
 - LibreQoS moves the WebUI listener to `127.0.0.1:9123`.
 - Caddy proxies the WebUI and API docs over HTTPS.
 - Managed Caddy mode proxies API requests to `127.0.0.1:9122`, so the API stays behind the same HTTPS origin as the WebUI.
-- Swagger moves to `/api/v1/api-docs` on the same HTTPS origin as the WebUI.
+- Swagger moves to `/api-docs/` on the same HTTPS origin as the WebUI.
+
+The API documentation is public; API requests still require an API key. Existing `/api/v1/api-docs` links redirect to `/api-docs/`.
+
+After upgrading an existing HTTPS installation, reapply your settings in `Configuration -> SSL Setup` to update the Caddy routes. This regenerates `/etc/caddy/Caddyfile`, replacing manual edits, and restarts Caddy, the WebUI, and the API service.
 
 ## API Listen Overrides
 

--- a/src/rust/lqos_setup/src/ssl.rs
+++ b/src/rust/lqos_setup/src/ssl.rs
@@ -547,7 +547,7 @@ fn render_managed_caddyfile(plan: &SslRuntimePlan) -> String {
     format!(
         "\
 {{\n    admin off\n}}\n\n\
-{site_address} {{{tls_block}\n    encode zstd gzip\n    handle /api/v1 {{\n        redir /api/v1/ 308\n    }}\n    handle_path /api/v1/* {{\n        reverse_proxy {api_upstream}\n    }}\n    reverse_proxy {web_upstream}\n}}\n",
+{site_address} {{{tls_block}\n    encode zstd gzip\n    @apidocs path /api-docs /api-docs/*\n    handle @apidocs {{\n        reverse_proxy {api_upstream}\n    }}\n    handle /api/v1 {{\n        redir /api/v1/ 308\n    }}\n    handle_path /api/v1/* {{\n        reverse_proxy {api_upstream}\n    }}\n    reverse_proxy {web_upstream}\n}}\n",
         site_address = plan.caddy_site_address,
         tls_block = tls_block,
         api_upstream = API_UPSTREAM,
@@ -644,7 +644,7 @@ mod tests {
         let plan = build_runtime_plan(Some("libreqos.example.com".to_string()), None);
         let caddyfile = render_managed_caddyfile(&plan);
         let expected = format!(
-            "{{\n    admin off\n}}\n\nlibreqos.example.com {{\n    encode zstd gzip\n    handle /api/v1 {{\n        redir /api/v1/ 308\n    }}\n    handle_path /api/v1/* {{\n        reverse_proxy {API_UPSTREAM}\n    }}\n    reverse_proxy {WEB_UPSTREAM}\n}}\n"
+            "{{\n    admin off\n}}\n\nlibreqos.example.com {{\n    encode zstd gzip\n    @apidocs path /api-docs /api-docs/*\n    handle @apidocs {{\n        reverse_proxy {API_UPSTREAM}\n    }}\n    handle /api/v1 {{\n        redir /api/v1/ 308\n    }}\n    handle_path /api/v1/* {{\n        reverse_proxy {API_UPSTREAM}\n    }}\n    reverse_proxy {WEB_UPSTREAM}\n}}\n"
         );
         assert_eq!(caddyfile, expected);
     }


### PR DESCRIPTION
Managed HTTPS strips `/api/v1` before forwarding API requests, but Swagger redirects and its schema URL use `/api-docs` at the hostname root. Route `/api-docs` and `/api-docs/*` unchanged to the API service so the existing iframe can follow the redirect and load its schema.

Update English and Spanish API/HTTPS guides with the documentation URL and instructions for regenerating existing managed configurations. Update the existing configuration expectation; add no new tests or dependencies.

Validation: all 24 lqos_setup tests pass; cargo check, clippy with -D warnings, rustfmt, and git diff --check pass. Caddy is not installed locally, so no live proxy/browser validation was run. Cargo audit reports the existing h2 advisory RUSTSEC-2026-0258 and eight warnings; dependency changes are outside this fix.

Fixes #1157.
